### PR TITLE
Hotfix RemoveExtraSpaces

### DIFF
--- a/modules/core/src/com/haulmont/cuba/core/app/DataServiceQueryBuilder.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/DataServiceQueryBuilder.java
@@ -172,6 +172,6 @@ public class DataServiceQueryBuilder {
         if (query == null)
             return null;
         else
-            return StringHelper.removeExtraSpaces(query.replace("\n", " "));
+            return StringUtils.normalizeSpace(query.replace("\n", " "));
     }
 }

--- a/modules/core/test/com/haulmont/cuba/core/ScriptingTest.java
+++ b/modules/core/test/com/haulmont/cuba/core/ScriptingTest.java
@@ -54,7 +54,7 @@ public class ScriptingTest {
     @Test
     public void testImportsEvaluate() {
         String result = scripting.evaluateGroovy("import org.apache.commons.lang.StringUtils\n" +
-                                                 "return StringUtlis.normalizeSpace(' Hello! ')", (Binding) null);
+                                                 "return StringUtils.normalizeSpace(' Hello! ')", (Binding) null);
         assertNotNull(result);
     }
 

--- a/modules/core/test/com/haulmont/cuba/core/ScriptingTest.java
+++ b/modules/core/test/com/haulmont/cuba/core/ScriptingTest.java
@@ -53,16 +53,16 @@ public class ScriptingTest {
 
     @Test
     public void testImportsEvaluate() {
-        String result = scripting.evaluateGroovy("import com.haulmont.bali.util.StringHelper\n" +
-                                                 "return StringHelper.removeExtraSpaces(' Hello! ')", (Binding) null);
+        String result = scripting.evaluateGroovy("import org.apache.commons.lang.StringUtils\n" +
+                                                 "return StringUtlis.normalizeSpace(' Hello! ')", (Binding) null);
         assertNotNull(result);
     }
 
     @Test
     public void testPackageAndImportsEvaluate() {
         String result = scripting.evaluateGroovy("package com.haulmont.cuba.core\n" +
-                "import com.haulmont.bali.util.StringHelper\n" +
-                "return StringHelper.removeExtraSpaces(' Hello! ')", (Binding) null);
+                "import org.apache.commons.lang.StringUtils\n" +
+                "return StringUtils.normalizeSpace(' Hello! ')", (Binding) null);
         assertNotNull(result);
     }
 

--- a/modules/global/src/com/haulmont/bali/util/StringHelper.java
+++ b/modules/global/src/com/haulmont/bali/util/StringHelper.java
@@ -26,7 +26,9 @@ public final class StringHelper {
      * Examples:<br>
      * " aaa  bbb   ccc ddd " becomes "aaa bbb ccc ddd"
      *
+     * @deprecated use {@link org.apache.commons.lang.StringUtils#normalizeSpace(String)} instead
     */
+    @Deprecated
     public static String removeExtraSpaces(String str) {
         StringBuilder sb = new StringBuilder();
 

--- a/modules/global/src/com/haulmont/bali/util/StringHelper.java
+++ b/modules/global/src/com/haulmont/bali/util/StringHelper.java
@@ -16,6 +16,8 @@
  */
 package com.haulmont.bali.util;
 
+import org.apache.commons.lang.StringUtils;
+
 public final class StringHelper {
 
     private StringHelper() {
@@ -30,26 +32,6 @@ public final class StringHelper {
     */
     @Deprecated
     public static String removeExtraSpaces(String str) {
-        StringBuilder sb = new StringBuilder();
-
-        int pos = 0;
-        boolean prevWS = true;
-
-        for (int i = 0; i < str.length(); i++) {
-            if (Character.isWhitespace(str.charAt(i)) || i == str.length() - 1) {
-                if (!prevWS) {
-                    sb.append(str.substring(pos, i)).append(str.charAt(i));
-                }
-                prevWS = true;
-            } else {
-                if (prevWS)
-                    pos = i;
-                prevWS = false;
-            }
-        }
-        if (Character.isWhitespace(sb.charAt(sb.length() - 1)))
-            sb.deleteCharAt(sb.length() - 1);
-
-        return sb.toString();
+        return StringUtils.normalizeSpace(str);
     }
 }

--- a/modules/global/test/com/haulmont/bali/util/StringHelperTest.java
+++ b/modules/global/test/com/haulmont/bali/util/StringHelperTest.java
@@ -1,0 +1,37 @@
+package com.haulmont.bali.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Dmitry Chigileychik
+ * @since 08.02.17.
+ */
+public class StringHelperTest {
+
+    @Test
+    public void testEmptyStringNormalize() {
+        String result = StringHelper.removeExtraSpaces("");
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testStringNormalize() {
+        String result = StringHelper.removeExtraSpaces(" aaa  bbb   ccc ddd ");
+        Assert.assertEquals("aaa bbb ccc ddd",result);
+    }
+
+    @Test
+    public void compareWithApacheNormalize() {
+        String apacheResult = StringUtils.normalizeSpace(" aaa  bbb   ccc ddd ");
+        String haulmontResult = StringHelper.removeExtraSpaces(" aaa  bbb   ccc ddd ");
+        Assert.assertEquals(apacheResult, haulmontResult);
+    }
+
+    @Test
+    public void testApacheNormalizeEmptyString() {
+        String result = StringUtils.normalizeSpace("");
+        Assert.assertEquals("", result);
+    }
+}

--- a/modules/gui/src/com/haulmont/cuba/gui/components/actions/FilterApplyAction.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/actions/FilterApplyAction.java
@@ -21,7 +21,7 @@ import com.haulmont.cuba.gui.components.Component;
 import com.haulmont.cuba.gui.components.ListComponent;
 
 /**
- * DEPRECATED. List action to apply current filter by refreshing the underlying datasource.
+ * @deprecated List action to apply current filter by refreshing the underlying datasource.
  */
 @Deprecated
 public class FilterApplyAction extends AbstractAction {
@@ -32,7 +32,8 @@ public class FilterApplyAction extends AbstractAction {
 
     /**
      * The simplest constructor. The action has default name.
-     * @param owner    component containing this action
+     *
+     * @param owner component containing this action
      */
     public FilterApplyAction(ListComponent owner) {
         this(owner, ACTION_ID);
@@ -40,8 +41,9 @@ public class FilterApplyAction extends AbstractAction {
 
     /**
      * Constructor that allows to specify the action name.
-     * @param owner    component containing this action
-     * @param id        action name
+     *
+     * @param owner component containing this action
+     * @param id    action name
      */
     public FilterApplyAction(ListComponent owner, String id) {
         super(id);

--- a/modules/web/src/com/haulmont/cuba/web/app/folders/CubaFoldersPane.java
+++ b/modules/web/src/com/haulmont/cuba/web/app/folders/CubaFoldersPane.java
@@ -119,7 +119,7 @@ public class CubaFoldersPane extends VerticalLayout {
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(C_FOLDERS_PANE, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(C_FOLDERS_PANE, ""));
     }
 
     public void loadFolders() {

--- a/modules/web/src/com/haulmont/cuba/web/gui/WebWindow.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/WebWindow.java
@@ -194,7 +194,7 @@ public class WebWindow implements Window, Component.Wrapper,
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(component.getStyleName().replace(C_WINDOW_LAYOUT, ""));
+        return StringUtils.normalizeSpace(component.getStyleName().replace(C_WINDOW_LAYOUT, ""));
     }
 
     @Override
@@ -1667,7 +1667,7 @@ public class WebWindow implements Window, Component.Wrapper,
 
         @Override
         public String getStyleName() {
-            return StringHelper.removeExtraSpaces(container.getStyleName().replace(C_WINDOW_LAYOUT, ""));
+            return StringUtils.normalizeSpace(container.getStyleName().replace(C_WINDOW_LAYOUT, ""));
         }
 
         @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebAbstractTable.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebAbstractTable.java
@@ -1223,7 +1223,7 @@ public abstract class WebAbstractTable<T extends com.vaadin.ui.Table & CubaEnhan
         for (String internalStyle : internalStyles) {
             styleName = styleName.replace(internalStyle, "");
         }
-        return StringHelper.removeExtraSpaces(styleName);
+        return StringUtils.normalizeSpace(styleName);
     }
 
     public void validate() throws ValidationException {

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebButton.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebButton.java
@@ -121,7 +121,7 @@ public class WebButton extends WebAbstractComponent<CubaButton> implements Butto
     @Override
     public String getStyleName() {
         if (getIcon() != null)
-            return StringHelper.removeExtraSpaces(super.getStyleName().replace(ICON_STYLE, ""));
+            return StringUtils.normalizeSpace(super.getStyleName().replace(ICON_STYLE, ""));
 
         return super.getStyleName();
     }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebButtonsPanel.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebButtonsPanel.java
@@ -19,6 +19,7 @@ package com.haulmont.cuba.web.gui.components;
 import com.haulmont.bali.util.StringHelper;
 import com.haulmont.cuba.gui.components.ButtonsPanel;
 import com.haulmont.cuba.gui.components.VisibilityChangeNotifier;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -45,7 +46,7 @@ public class WebButtonsPanel extends WebHBoxLayout implements ButtonsPanel, Visi
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(BUTTONS_PANNEL_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(BUTTONS_PANNEL_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebFlowBoxLayout.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebFlowBoxLayout.java
@@ -20,6 +20,7 @@ import com.haulmont.bali.util.StringHelper;
 import com.haulmont.cuba.gui.components.FlowBoxLayout;
 import com.haulmont.cuba.web.toolkit.ui.CubaFlowLayout;
 import com.vaadin.shared.ui.MarginInfo;
+import org.apache.commons.lang.StringUtils;
 
 public class WebFlowBoxLayout extends WebAbstractOrderedLayout<CubaFlowLayout> implements FlowBoxLayout {
 
@@ -38,7 +39,7 @@ public class WebFlowBoxLayout extends WebAbstractOrderedLayout<CubaFlowLayout> i
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(FLOWLAYOUT_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(FLOWLAYOUT_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebGroupBox.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebGroupBox.java
@@ -28,6 +28,7 @@ import com.haulmont.cuba.web.toolkit.ui.CubaOrderedActionsLayout;
 import com.haulmont.cuba.web.toolkit.ui.CubaVerticalActionsLayout;
 import com.vaadin.ui.AbstractOrderedLayout;
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
 import org.dom4j.Element;
 
 import javax.annotation.Nonnull;
@@ -378,6 +379,6 @@ public class WebGroupBox extends WebAbstractComponent<CubaGroupBox> implements G
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(GROUPBOX_PANEL_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(GROUPBOX_PANEL_STYLENAME, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebLabel.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebLabel.java
@@ -286,6 +286,6 @@ public class WebLabel extends WebAbstractComponent<com.vaadin.ui.Label> implemen
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(CAPTION_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(CAPTION_STYLENAME, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebLinkButton.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebLinkButton.java
@@ -20,6 +20,7 @@ package com.haulmont.cuba.web.gui.components;
 import com.haulmont.bali.util.StringHelper;
 import com.haulmont.cuba.gui.components.LinkButton;
 import com.vaadin.ui.themes.BaseTheme;
+import org.apache.commons.lang.StringUtils;
 
 public class WebLinkButton extends WebButton implements LinkButton {
 
@@ -35,6 +36,6 @@ public class WebLinkButton extends WebButton implements LinkButton {
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(BaseTheme.BUTTON_LINK, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(BaseTheme.BUTTON_LINK, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebListEditor.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebListEditor.java
@@ -23,6 +23,7 @@ import com.haulmont.cuba.gui.components.ListEditor;
 import com.haulmont.cuba.gui.components.listeditor.ListEditorDelegate;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomField;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class WebListEditor extends WebAbstractField<WebListEditor.CubaListEditor
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(LISTEDITOR_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(LISTEDITOR_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebRowsCount.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebRowsCount.java
@@ -27,6 +27,7 @@ import com.haulmont.cuba.gui.data.CollectionDatasource.Operation;
 import com.haulmont.cuba.gui.data.Datasource;
 import com.haulmont.cuba.gui.data.impl.WeakCollectionChangeListener;
 import com.haulmont.cuba.web.toolkit.ui.CubaRowsCount;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -56,7 +57,7 @@ public class WebRowsCount extends WebAbstractComponent<CubaRowsCount> implements
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(TABLE_ROWS_COUNT_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(TABLE_ROWS_COUNT_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebScrollBoxLayout.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebScrollBoxLayout.java
@@ -28,6 +28,7 @@ import com.vaadin.server.Sizeable;
 import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.AbstractOrderedLayout;
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -146,7 +147,7 @@ public class WebScrollBoxLayout extends WebAbstractComponent<CubaScrollBoxPanel>
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(SCROLLBOX_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(SCROLLBOX_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebSearchField.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebSearchField.java
@@ -149,7 +149,7 @@ public class WebSearchField extends WebLookupField implements SearchField {
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(SEARCHSELECT_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(SEARCHSELECT_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebAppMenu.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebAppMenu.java
@@ -24,6 +24,7 @@ import com.haulmont.cuba.gui.components.mainwindow.TopLevelWindowAttachListener;
 import com.haulmont.cuba.web.gui.components.WebAbstractComponent;
 import com.haulmont.cuba.web.sys.MenuBuilder;
 import com.haulmont.cuba.web.toolkit.ui.CubaMenuBar;
+import org.apache.commons.lang.StringUtils;
 
 public class WebAppMenu extends WebAbstractComponent<CubaMenuBar>
         implements AppMenu, TopLevelWindowAttachListener {
@@ -44,7 +45,7 @@ public class WebAppMenu extends WebAbstractComponent<CubaMenuBar>
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(MENU_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(MENU_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebAppWorkArea.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebAppWorkArea.java
@@ -36,6 +36,7 @@ import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.themes.ValoTheme;
 import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
 import fi.jasoft.dragdroplayouts.drophandlers.DefaultTabSheetDropHandler;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -103,7 +104,7 @@ public class WebAppWorkArea extends WebAbstractComponent<CssLayout> implements A
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName()
+        return StringUtils.normalizeSpace(super.getStyleName()
                 .replace(WORKAREA_STYLENAME, "")
                 .replace(MODE_TABBED_STYLENAME, "")
                 .replace(MODE_SINGLE_STYLENAME, "")

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebFoldersPane.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebFoldersPane.java
@@ -21,6 +21,7 @@ import com.haulmont.bali.util.StringHelper;
 import com.haulmont.cuba.gui.components.mainwindow.FoldersPane;
 import com.haulmont.cuba.web.app.folders.CubaFoldersPane;
 import com.haulmont.cuba.web.gui.components.WebAbstractComponent;
+import org.apache.commons.lang.StringUtils;
 
 import static com.haulmont.cuba.web.app.folders.CubaFoldersPane.C_FOLDERS_PANE;
 
@@ -43,7 +44,7 @@ public class WebFoldersPane extends WebAbstractComponent<CubaFoldersPane> implem
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(C_FOLDERS_PANE, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(C_FOLDERS_PANE, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebFtsField.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebFtsField.java
@@ -134,6 +134,6 @@ public class WebFtsField extends WebAbstractComponent<HorizontalLayout> implemen
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(FTS_FIELD_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(FTS_FIELD_STYLENAME, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebLogoutButton.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebLogoutButton.java
@@ -22,6 +22,7 @@ import com.haulmont.cuba.gui.components.mainwindow.LogoutButton;
 import com.haulmont.cuba.web.AppUI;
 import com.haulmont.cuba.web.gui.components.WebAbstractComponent;
 import com.haulmont.cuba.web.toolkit.ui.CubaButton;
+import org.apache.commons.lang.StringUtils;
 
 public class WebLogoutButton extends WebAbstractComponent<CubaButton> implements LogoutButton {
 
@@ -50,6 +51,6 @@ public class WebLogoutButton extends WebAbstractComponent<CubaButton> implements
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(LOGOUT_BUTTON_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(LOGOUT_BUTTON_STYLENAME, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebNewWindowButton.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebNewWindowButton.java
@@ -24,6 +24,7 @@ import com.haulmont.cuba.web.toolkit.ui.CubaButton;
 import com.vaadin.server.BrowserWindowOpener;
 import com.vaadin.server.ExternalResource;
 import com.vaadin.server.Page;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
@@ -62,6 +63,6 @@ public class WebNewWindowButton extends WebAbstractComponent<CubaButton> impleme
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(NEW_WINDOW_BUTTON_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(NEW_WINDOW_BUTTON_STYLENAME, ""));
     }
 }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebTimeZoneIndicator.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebTimeZoneIndicator.java
@@ -24,6 +24,7 @@ import com.haulmont.cuba.core.global.UserSessionSource;
 import com.haulmont.cuba.gui.components.mainwindow.TimeZoneIndicator;
 import com.haulmont.cuba.web.gui.components.WebAbstractComponent;
 import com.vaadin.ui.Label;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.TimeZone;
 
@@ -48,7 +49,7 @@ public class WebTimeZoneIndicator extends WebAbstractComponent<Label> implements
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(USER_TIMEZONE_LABEL_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(USER_TIMEZONE_LABEL_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebUserIndicator.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/mainwindow/WebUserIndicator.java
@@ -69,7 +69,7 @@ public class WebUserIndicator extends WebAbstractComponent<CubaCssLayout> implem
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(USER_INDICATOR_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(USER_INDICATOR_STYLENAME, ""));
     }
 
     @Override

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/presentations/TablePresentations.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/presentations/TablePresentations.java
@@ -130,7 +130,7 @@ public class TablePresentations extends VerticalLayout {
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(TABLE_PREFS_STYLENAME, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(TABLE_PREFS_STYLENAME, ""));
     }
 
     protected void removeCurrentItemStyle(com.vaadin.ui.MenuBar.MenuItem item) {

--- a/modules/web/src/com/haulmont/cuba/web/sys/WindowBreadCrumbs.java
+++ b/modules/web/src/com/haulmont/cuba/web/sys/WindowBreadCrumbs.java
@@ -111,7 +111,7 @@ public class WindowBreadCrumbs extends CssLayout {
 
     @Override
     public String getStyleName() {
-        return StringHelper.removeExtraSpaces(super.getStyleName().replace(C_HEADLINE_CONTAINER, ""));
+        return StringUtils.normalizeSpace(super.getStyleName().replace(C_HEADLINE_CONTAINER, ""));
     }
 
     protected Layout createEnclosingLayout() {


### PR DESCRIPTION
There is an error in com.haulmont.bali.util.StringHelper#removeExtraSpaces(String): if you pass an empty string there will be an StringIndexOutOfBoundsException. (We catch this error when called com.haulmont.cuba.gui.components.Component#getStyleName for a button, that have icon and have empty stylename)

I replaced this method usages with org.apache.commons.lang.StringUtils#normalizeSpace(String) and deprecated previous. I didn't fix or delegated removeExtraSpaces(String) execution.

I wrote test class to demonstrate that methods are equal and to show this error.