### PR TITLE
Hotfix: wrong nested parent datasource

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractDatasource.java
@@ -184,6 +184,7 @@ public abstract class AbstractDatasource<T extends Entity> implements Datasource
                 // Look for corresponding property datasource in the Parent's DsContext
                 for (Datasource siblingOfParent : parentDs.getDsContext().getAll()) {
                     if (siblingOfParent instanceof NestedDatasource
+                            && ((NestedDatasource) siblingOfParent).getProperty().equals(((NestedDatasource) sibling).getProperty())
                             && ((NestedDatasource) siblingOfParent).getMaster() == parentDs) {
                         // If such corresponding datasource found, set it as a parent for our property datasource
                         ((DatasourceImplementation) sibling).setParent(siblingOfParent);

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractDatasource.java
@@ -175,23 +175,18 @@ public abstract class AbstractDatasource<T extends Entity> implements Datasource
             return;
         }
 
-        // Iterate through all datasources in the same DsContext
-        for (Datasource sibling : getDsContext().getAll()) {
-            // If the datasource is a property datasource of the Child
-            if (sibling instanceof NestedDatasource
-                    && ((NestedDatasource) sibling).getMaster().equals(this)
-                    && !metadata.getTools().isEmbeddable(sibling.getMetaClass())) {
-                // Look for corresponding property datasource in the Parent's DsContext
-                for (Datasource siblingOfParent : parentDs.getDsContext().getAll()) {
-                    if (siblingOfParent instanceof NestedDatasource
-                            && ((NestedDatasource) siblingOfParent).getProperty().equals(((NestedDatasource) sibling).getProperty())
-                            && ((NestedDatasource) siblingOfParent).getMaster() == parentDs) {
-                        // If such corresponding datasource found, set it as a parent for our property datasource
-                        ((DatasourceImplementation) sibling).setParent(siblingOfParent);
-                    }
-                }
-            }
-        }
+        getDsContext().getAll().stream()
+                .filter(sibling -> !metadata.getTools().isEmbeddable(sibling.getMetaClass()))
+                .filter(sibling -> sibling instanceof NestedDatasource)
+                .map(sibling -> (NestedDatasource) sibling)
+                .filter(sibling -> sibling.getMaster().equals(AbstractDatasource.this))
+                .forEach(sibling -> ((DatasourceImplementation) sibling).setParent(parentDs.getDsContext().getAll().stream()
+                        .filter(siblingOfParent -> siblingOfParent instanceof NestedDatasource)
+                        .map(siblingOfParent -> (NestedDatasource) siblingOfParent)
+                        .filter(siblingOfParent -> siblingOfParent.getMaster() == parentDs)
+                        .filter(siblingOfParent -> sibling.getProperty().equals(siblingOfParent.getProperty()))
+                        .findAny()
+                        .orElse(null)));
     }
 
     @Override


### PR DESCRIPTION
if there are several nested datasources in parentDs any of them could be setted as a parent for nested datasources of childDs
You could see an example project in attachments: create entity one, then click "Open Editor" button, add Entity Three, click OK an you'' catch an exception about missing property - it's because created entity added into wrong parent nested ds.

[wrong-nested.zip](https://github.com/cuba-platform/cuba/files/777258/wrong-nested.zip)
