### PR TITLE
PL-9558 Composite locale cannot be used in user language

### DIFF
--- a/modules/core/src/com/haulmont/cuba/security/app/IdpServiceBean.java
+++ b/modules/core/src/com/haulmont/cuba/security/app/IdpServiceBean.java
@@ -21,6 +21,7 @@ import com.haulmont.cuba.core.global.UuidSource;
 import com.haulmont.cuba.security.entity.User;
 import com.haulmont.cuba.security.global.IdpSession;
 import com.haulmont.cuba.security.global.LoginException;
+import org.apache.commons.lang.LocaleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,7 @@ public class IdpServiceBean implements IdpService {
 
         Locale userLocale = locale;
         if (user.getLanguage() != null && !globalConfig.getLocaleSelectVisible()) {
-            userLocale = new Locale(user.getLanguage());
+            userLocale = LocaleUtils.toLocale(user.getLanguage());
         }
 
         session.setLocale(userLocale.toLanguageTag());

--- a/modules/core/src/com/haulmont/cuba/security/app/LoginWorkerBean.java
+++ b/modules/core/src/com/haulmont/cuba/security/app/LoginWorkerBean.java
@@ -32,6 +32,7 @@ import com.haulmont.cuba.security.global.UserSession;
 import com.haulmont.cuba.security.sys.TrustedLoginHandler;
 import com.haulmont.cuba.security.sys.UserSessionManager;
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +142,7 @@ public class LoginWorkerBean implements LoginWorker, AppContext.Listener, Ordere
 
             Locale userLocale = locale;
             if (user.getLanguage() != null && !globalConfig.getLocaleSelectVisible()) {
-                userLocale = new Locale(user.getLanguage());
+                userLocale = LocaleUtils.toLocale(user.getLanguage());
             }
 
             UserSession session = userSessionManager.createSession(user, userLocale, false);
@@ -297,7 +298,7 @@ public class LoginWorkerBean implements LoginWorker, AppContext.Listener, Ordere
             Locale userLocale = locale;
             if (user.getLanguage() != null &&
                     BooleanUtils.isFalse(globalConfig.getLocaleSelectVisible())) {
-                userLocale = new Locale(user.getLanguage());
+                userLocale = LocaleUtils.toLocale(user.getLanguage());
             }
             UserSession session = userSessionManager.createSession(user, userLocale, false);
             checkPermissions(login, params, userLocale, session);
@@ -339,7 +340,7 @@ public class LoginWorkerBean implements LoginWorker, AppContext.Listener, Ordere
             Locale userLocale = locale;
             if (user.getLanguage() != null &&
                     BooleanUtils.isFalse(globalConfig.getLocaleSelectVisible())) {
-                userLocale = new Locale(user.getLanguage());
+                userLocale = LocaleUtils.toLocale(user.getLanguage());
             }
             UserSession session = userSessionManager.createSession(user, userLocale, false);
             checkPermissions(login, params, userLocale, session);
@@ -459,7 +460,7 @@ public class LoginWorkerBean implements LoginWorker, AppContext.Listener, Ordere
             Locale userLocale = locale;
             if (user.getLanguage() != null &&
                     BooleanUtils.isFalse(globalConfig.getLocaleSelectVisible())) {
-                userLocale = new Locale(user.getLanguage());
+                userLocale = LocaleUtils.toLocale(user.getLanguage());
             }
 
             UserSession session = userSessionManager.createSession(user, userLocale, false);

--- a/modules/desktop/src/com/haulmont/cuba/desktop/LoginDialog.java
+++ b/modules/desktop/src/com/haulmont/cuba/desktop/LoginDialog.java
@@ -24,6 +24,7 @@ import com.haulmont.cuba.desktop.sys.LoginProperties;
 import com.haulmont.cuba.security.app.LoginService;
 import com.haulmont.cuba.security.global.LoginException;
 import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -250,11 +251,7 @@ public class LoginDialog extends JDialog {
         Locale appLocale;
         String lastLocale = this.loginProperties.loadLastLocale();
         if (StringUtils.isNotEmpty(lastLocale)) {
-            String[] locParts = lastLocale.split("_");
-            if (locParts.length == 1)
-                appLocale = new Locale(locParts[0]);
-            else
-                appLocale = new Locale(locParts[0], locParts[1]);
+            appLocale = LocaleUtils.toLocale(lastLocale);
         } else {
             appLocale = Locale.getDefault();
         }

--- a/modules/global/src/com/haulmont/cuba/core/sys/AvailableLocalesFactory.java
+++ b/modules/global/src/com/haulmont/cuba/core/sys/AvailableLocalesFactory.java
@@ -17,10 +17,10 @@
 package com.haulmont.cuba.core.sys;
 
 import com.haulmont.cuba.core.config.type.TypeFactory;
+import org.apache.commons.lang.LocaleUtils;
 
-import java.util.Locale;
-import java.util.Map;
-import java.util.LinkedHashMap;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class AvailableLocalesFactory extends TypeFactory {
 
@@ -29,19 +29,11 @@ public class AvailableLocalesFactory extends TypeFactory {
         if (string == null)
             return null;
 
-        String[] items = string.split(";");
-        Map<String, Locale> map = new LinkedHashMap<>(items.length);
-        for (String item : items) {
-            String[] parts = item.split("\\|");
-            String[] locParts = parts[1].split("_");
-            Locale loc;
-            if (locParts.length == 1)
-                loc = new Locale(parts[1]);
-            else
-                loc = new Locale(locParts[0], locParts[1]);
-
-            map.put(parts[0], loc);
-        }
-        return map;
+        return Arrays.stream(string.split(";"))
+                .map(item -> item.split("\\|"))
+                .collect(Collectors.toMap(
+                        parts -> parts[0],
+                        parts -> LocaleUtils.toLocale(parts[1])
+                ));
     }
 }

--- a/modules/rest-api/src/com/haulmont/cuba/restapi/LoginServiceController.java
+++ b/modules/rest-api/src/com/haulmont/cuba/restapi/LoginServiceController.java
@@ -27,6 +27,7 @@ import com.haulmont.cuba.security.app.LoginService;
 import com.haulmont.cuba.security.app.UserSessionService;
 import com.haulmont.cuba.security.global.LoginException;
 import com.haulmont.cuba.security.global.UserSession;
+import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -130,7 +131,7 @@ public class LoginServiceController {
     protected Locale localeFromString(String localeStr) {
         return StringUtils.isBlank(localeStr) ?
                 globalConfig.getAvailableLocales().values().iterator().next()
-                : new Locale(localeStr);
+                : LocaleUtils.toLocale(localeStr);
     }
 
     protected void doLogin(String username, String password, String localeStr,


### PR DESCRIPTION
How to reproduce:

1. Setup locale properties with simple and composite locale 
`cuba.availableLocales=English|en;Russian|ru;Russia|ru_RU`
2. Disable visiblity of locale select
`cuba.localeSelectVisible = false`
3. Run application
4. Log in
5. Select complex lang in user preferences ('Russia')
6. Log out
7. Log in
8. Application runs in default locale