### PR TITLE
PL-9422 Table aggregation mechanism breaks result of Vaadin method com.vaadin.ui.Table.setColumnFooter

### DIFF
--- a/modules/web/src/com/haulmont/cuba/web/toolkit/ui/CubaTable.java
+++ b/modules/web/src/com/haulmont/cuba/web/toolkit/ui/CubaTable.java
@@ -676,7 +676,7 @@ public class CubaTable extends com.vaadin.ui.Table implements TableContainer, Cu
         Context context = new Context(getAggregationItemIds());
         Map<Object, Object> aggregations = ((AggregationContainer) items).aggregate(context);
         for (final Object columnId : visibleColumns) {
-            if (columnId == null || isColumnCollapsed(columnId)) {
+            if (columnId == null || isColumnCollapsed(columnId) || !aggregations.containsKey(columnId)) {
                 continue;
             }
 


### PR DESCRIPTION
The problem is that you can not use cuba aggregations mechanism for one column with com.vaadin.ui.Table#setColumnFooter for other column simultaneously