### PR TITLE
PL-9524 Selected item in nested datasource isn't cleared when master datasource is refreshed

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
@@ -101,7 +101,11 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
                 }
             }
 
-            item = null;
+            if (item != null) {
+                T prevItem = item;
+                item = null;
+                fireItemChanged(prevItem);
+            }
             fireCollectionChanged(Operation.REFRESH, Collections.emptyList());
         });
 

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
@@ -101,6 +101,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
                 }
             }
 
+            item = null;
             fireCollectionChanged(Operation.REFRESH, Collections.emptyList());
         });
 


### PR DESCRIPTION
1) Exists two datasources. A (with two items), B. B nested in A. Exists two tables A', B', associated with relevant datasources.
2) Select first item in A' table.
3) In the table B' will be displayed related items with the selected item of table A'. Select any item.
4) Select second item in A' table. 
5) Data in B' table will be refreshed.
6) Select first item in A' table.

AR: Selection in B table isn't removed
ER: Selection in B table is removed