### PR TITLE
NPE on sorting datasource by persistent field which have non-persistent fields in Name Pattern

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
@@ -641,28 +641,30 @@ public abstract class AbstractCollectionDatasource<T extends Entity<K>, K>
 
     @Nullable
     protected String[] getSortPropertiesForPersistentAttribute(MetaPropertyPath propertyPath) {
-        ArrayList<String> props = new ArrayList<>();
+        String[] sortProperties = null;
         if (!propertyPath.getMetaProperty().getRange().isClass()) {
             // a scalar persistent attribute
-            props.add(propertyPath.toString());
+            sortProperties = new String[1];
+            sortProperties[0] = propertyPath.toString();
         } else {
+
             // a reference attribute
             MetaClass metaClass = propertyPath.getMetaProperty().getRange().asClass();
             if (!propertyPath.getMetaProperty().getRange().getCardinality().isMany()) {
                 Collection<MetaProperty> properties = metadata.getTools().getNamePatternProperties(metaClass);
                 if (!properties.isEmpty()) {
-                    properties.stream()
+                    sortProperties = properties.stream()
                             .filter(metaProperty -> metadata.getTools().isPersistent(metaProperty))
                             .map(MetadataObject::getName)
                             .map(propName -> propertyPath.toString().concat(".").concat(propName))
-                            .forEach(props::add);
+                            .toArray(String[]::new);
                 } else {
-                    props.add(propertyPath.toString());
+                    sortProperties = new String[1];
+                    sortProperties[0] = propertyPath.toString();
                 }
             }
         }
-        props.trimToSize();
-        return props.isEmpty() ? null : props.toArray(new String[props.size()]);
+        return sortProperties;
     }
 
     @Override

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
@@ -654,7 +654,7 @@ public abstract class AbstractCollectionDatasource<T extends Entity<K>, K>
                     properties.stream()
                             .filter(metaProperty -> metadata.getTools().isPersistent(metaProperty))
                             .map(MetadataObject::getName)
-                            .map(propName -> propertyPath.toString().concat(propName))
+                            .map(propName -> propertyPath.toString().concat(".").concat(propName))
                             .forEach(props::add);
                 } else {
                     props.add(propertyPath.toString());


### PR DESCRIPTION
How to reproduce:
1. Create an entity with non persistent name pattern fields:
```
@NamePattern("%s %s|code,name")
@Table(name = "MYAPP_FOO")
@Entity(name = "myapp$Foo")
public class Foo extends StandardEntity {
    @MetaProperty
    public String getName() { <...> }

    @MetaProperty
    public String getCode() { <...> }
}
```
2. Create an entity with reference to previous one:
```
@Table(name = "MYAPP_BAR")
@Entity(name = "myapp$Bar")
public class Bar extends StandardEntity {
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "FOO_ID")
    protected Foo foo;
}
```
3. Create a screen with table of second one entities and with column on reference field
```
<table id="barTable">
    <columns>
        <column id="foo">
        <...>
    </columns>
    <rows datasource="barsDs"/>
</table>
```
4. Enable sorting by this column