### PR TITLE
fix entity inspector editor

### DIFF
--- a/modules/global/src/com/haulmont/cuba/core/entity/EntitySnapshot.java
+++ b/modules/global/src/com/haulmont/cuba/core/entity/EntitySnapshot.java
@@ -144,7 +144,7 @@ public class EntitySnapshot extends BaseUuidEntity implements Creatable {
         return StringUtils.trim(name);
     }
 
-    @MetaProperty
+    @MetaProperty(related = "snapshotDate")
     public Date getChangeDate() {
         return this.snapshotDate;
     }

--- a/modules/global/src/com/haulmont/cuba/core/entity/EntitySnapshot.java
+++ b/modules/global/src/com/haulmont/cuba/core/entity/EntitySnapshot.java
@@ -127,7 +127,7 @@ public class EntitySnapshot extends BaseUuidEntity implements Creatable {
         return author;
     }
 
-    @MetaProperty
+    @MetaProperty(related = {"snapshotDate,author"})
     public String getLabel() {
         String name = "";
         if (author != null && StringUtils.isNotEmpty(this.author.getCaption())) {

--- a/modules/global/src/com/haulmont/cuba/core/global/MetadataTools.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/MetadataTools.java
@@ -706,22 +706,6 @@ public class MetadataTools {
     }
 
     /**
-     * Determine whether the given metaProperty relates to at least one non local property
-     */
-    public boolean isRelatedToNonLocalProperty(MetaProperty metaProperty) {
-        checkNotNullArgument(metaProperty, "metaProperty is null");
-
-        MetaClass metaClass = metaProperty.getDomain();
-        for (String relatedProperty : metadata.getTools().getRelatedProperties(metaProperty)) {
-            //noinspection ConstantConditions
-            if (metaClass.getProperty(relatedProperty).getRange().isClass()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * If the given property is a reference to an entity from different data store, returns the name of a persistent
      * property which stores the identifier of the related entity.
      *

--- a/modules/global/src/com/haulmont/cuba/core/global/MetadataTools.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/MetadataTools.java
@@ -706,6 +706,22 @@ public class MetadataTools {
     }
 
     /**
+     * Determine whether the given metaProperty relates to at least one non local property
+     */
+    public boolean isRelatedToNonLocalProperty(MetaProperty metaProperty) {
+        checkNotNullArgument(metaProperty, "metaProperty is null");
+
+        MetaClass metaClass = metaProperty.getDomain();
+        for (String relatedProperty : metadata.getTools().getRelatedProperties(metaProperty)) {
+            //noinspection ConstantConditions
+            if (metaClass.getProperty(relatedProperty).getRange().isClass()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * If the given property is a reference to an entity from different data store, returns the name of a persistent
      * property which stores the identifier of the related entity.
      *

--- a/modules/gui/src/com/haulmont/cuba/gui/app/core/entityinspector/EntityInspectorEditor.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/app/core/entityinspector/EntityInspectorEditor.java
@@ -735,7 +735,7 @@ public class EntityInspectorEditor extends AbstractWindow {
         LinkedList<Table.Column> nonSystemPropertyColumns = new LinkedList<>();
         LinkedList<Table.Column> systemPropertyColumns = new LinkedList<>();
         for (MetaProperty metaProperty : meta.getProperties()) {
-            if (metaProperty.getRange().isClass() || metadata.getTools().isRelatedToNonLocalProperty(metaProperty))
+            if (metaProperty.getRange().isClass() || isRelatedToNonLocalProperty(metaProperty))
                 continue; // because we use local views
             Table.Column column = new Table.Column(meta.getPropertyPath(metaProperty.getName()));
             if (!metadata.getTools().isSystem(metaProperty)) {
@@ -774,6 +774,20 @@ public class EntityInspectorEditor extends AbstractWindow {
         TabSheet.Tab tab = tablesTabSheet.addTab(childMeta.toString(), vbox);
         tab.setCaption(getPropertyCaption(metaClass, childMeta));
         tables.add(table);
+    }
+
+    /**
+     * Determine whether the given metaProperty relates to at least one non local property
+     */
+    protected boolean isRelatedToNonLocalProperty(MetaProperty metaProperty) {
+        MetaClass metaClass = metaProperty.getDomain();
+        for (String relatedProperty : metadata.getTools().getRelatedProperties(metaProperty)) {
+            //noinspection ConstantConditions
+            if (metaClass.getProperty(relatedProperty).getRange().isClass()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/modules/gui/src/com/haulmont/cuba/gui/app/core/entityinspector/EntityInspectorEditor.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/app/core/entityinspector/EntityInspectorEditor.java
@@ -735,7 +735,7 @@ public class EntityInspectorEditor extends AbstractWindow {
         LinkedList<Table.Column> nonSystemPropertyColumns = new LinkedList<>();
         LinkedList<Table.Column> systemPropertyColumns = new LinkedList<>();
         for (MetaProperty metaProperty : meta.getProperties()) {
-            if (metaProperty.getRange().isClass())
+            if (metaProperty.getRange().isClass() || metadata.getTools().isRelatedToNonLocalProperty(metaProperty))
                 continue; // because we use local views
             Table.Column column = new Table.Column(meta.getPropertyPath(metaProperty.getName()));
             if (!metadata.getTools().isSystem(metaProperty)) {
@@ -917,10 +917,6 @@ public class EntityInspectorEditor extends AbstractWindow {
     protected View createView(MetaClass meta) {
         View view = new View(meta.getJavaClass(), false);
         for (MetaProperty metaProperty : meta.getProperties()) {
-            if (metaProperty.isReadOnly()) {
-                continue;
-            }
-
             switch (metaProperty.getType()) {
                 case DATATYPE:
                 case ENUM:


### PR DESCRIPTION
There were two bugs in entityInspector.edit screen.
1. Entity Foo has ManyToMany relation with EntitySnapshot, that has getLabel metaProperty. When you try to open entity Foo over entity inspector you will catch exception.
2. Entity Foo has readOnly MetaProperty "myProperty" related to other non local properties.
During view creation, "myProperty" will be scipped, but component for that property will be created and again you will get UnfetchedAttributeException.