### PR TITLE
MS SQL Server doesn't support Go as Transact-SQL statement

### DIFF
--- a/modules/core/db/update/mssql/17/170228-createRestApiTokenTable.sql
+++ b/modules/core/db/update/mssql/17/170228-createRestApiTokenTable.sql
@@ -11,5 +11,4 @@ if not exists (select * from sysobjects where name='SYS_REST_API_TOKEN')
     EXPIRY datetime,
     --
     primary key (ID)
-)
-go^
+)^


### PR DESCRIPTION
https://docs.microsoft.com/en-us/sql/t-sql/language-elements/sql-server-utilities-statements-go

GO is not a Transact-SQL statement; it is a command recognized by the sqlcmd and osql utilities and SQL Server Management Studio Code editor.
SQL Server utilities interpret GO as a signal that they should send the current batch of Transact-SQL statements to an instance of SQL Server. The current batch of statements is composed of all statements entered since the last GO, or since the start of the ad hoc session or script if this is the first GO.