### PR TITLE
Feature: merge all CollectionChangeEvent on suspend and fire them on resume

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
@@ -59,7 +59,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
 
     protected SortInfo<MetaPropertyPath>[] sortInfos;
     protected boolean listenersSuspended;
-    protected final LinkedList<Pair<Operation, List<T>>> suspendedEvents = new LinkedList<>();
+    protected final LinkedList<CollectionChangeEvent<T,K>> suspendedEvents = new LinkedList<>();
 
     protected boolean doNotModify;
 
@@ -804,10 +804,10 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
 
     protected void fireCollectionChanged(Operation operation, List<T> items) {
         if (listenersSuspended) {
-            if (!suspendedEvents.isEmpty() && suspendedEvents.getFirst().getFirst().equals(operation)) {
-                suspendedEvents.getFirst().getSecond().addAll(items);
+            if (!suspendedEvents.isEmpty() && suspendedEvents.getFirst().getOperation().equals(operation)) {
+                suspendedEvents.getFirst().getItems().addAll(items);
             } else {
-                suspendedEvents.addFirst(new Pair<>(operation, new ArrayList<>(items)));
+                suspendedEvents.addFirst(new CollectionChangeEvent<>(this, operation, new ArrayList<>(items)));
             }
             return;
         }
@@ -831,8 +831,8 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
 
         while(!suspendedEvents.isEmpty()) {
             //noinspection unchecked
-            Pair<Operation, List<T>> pair = suspendedEvents.removeLast();
-            fireCollectionChanged(pair.getFirst(), pair.getSecond());
+            CollectionChangeEvent<T,K> suspendedEvent = suspendedEvents.removeLast();
+            fireCollectionChanged(suspendedEvent.getOperation(), Collections.unmodifiableList(suspendedEvent.getItems()));
         }
     }
 


### PR DESCRIPTION
Suppose we've got such collection change listener:
```
@Inject
private CollectionDatasource cds;
@Inject
private CollectionDatasource anotherDs; 
<...>
cds.addCollectionChangeListener(e ->
    if (CollectionDatasource.Operation.ADD.equals(e.getOperation())) {
        e.getItems().forEach(anotherDs::addItem);
    } else if (CollectionDatasource.Operation.REMOVE.equals(e.getOperation())) {
        e.getItems().forEach(anotherDs::removeItem);
    }
});
```
Now we want to mess around with `cds`:
```
cds.suspendListeners();
getSomeItemsToRemove().forEach(cds::removeItem)
fooService.generateManyEntities().forEach(cds::addItem);
getSomeItemsToRemove().forEach(cds::removeItem) //there may be newly generated items
cds.resumeListeners();
```
If we not suspend listeners, there'll be CollectionChangeEvent on each item to remove or add and could take quite a while time. But on resume listener will be called only once with last removed item. So in `anotherDs` will not be synced with `cds`.

This improvement merges all consistent operations into one operation and in order they emerged. So listener in example will be called 3 times: 
1. REMOVE operations with all items in removed before new items added
2. ADD operations with all items added
3. REMOVE operation