### PR TITLE
Multiple sequences must not be used to generate ID in case of SINGLE_TABLE inheritance type

### DIFF
--- a/modules/global/src/com/haulmont/cuba/core/sys/MetadataImpl.java
+++ b/modules/global/src/com/haulmont/cuba/core/sys/MetadataImpl.java
@@ -168,10 +168,11 @@ public class MetadataImpl implements Metadata {
     protected String getEntityNameForIdGeneration(MetaClass metaClass) {
         MetaClass result = metaClass.getAncestors().stream()
                 .filter(mc -> {
-                    // use root of inheritance tree if the strategy is JOINED because ID is stored in the root table
+                    // use root of inheritance tree if the strategy is JOINED (ID is stored in the root table) or
+                    // the strategy is SINGLE_TABLE (ID is stored in single table for all entities)
                     Class<?> javaClass = mc.getJavaClass();
                     Inheritance inheritance = javaClass.getAnnotation(Inheritance.class);
-                    return inheritance != null && inheritance.strategy() == InheritanceType.JOINED;
+                    return inheritance != null && inheritance.strategy() != InheritanceType.TABLE_PER_CLASS;
                 })
                 .findFirst()
                 .orElse(metaClass);


### PR DESCRIPTION
Probably there is a bug in ID generation algorithm for integer and long primary keys. 

Currently values for numeric primary keys fetched from DB sequences which names corresponds to entities names, with one exception: when entities has `InheritanceType.JOINED` inheritance. But if `InheritanceType.SINGLE_TABLE` is used, then algorithm use individual sequence for each child entity and such behavior might lead to duplication of primary keys.

So individual sequences must be used only in two cases:
* entity inheritance not used;
* entity inheritance used in `InheritanceType.TABLE_PER_CLASS` mode.