### PR TITLE
Fixed bug when committing nested datasource to parent datasource, but it already has new items

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/PropertyDatasourceImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/PropertyDatasourceImpl.java
@@ -170,7 +170,11 @@ public class PropertyDatasourceImpl<T extends Entity>
             if (parentDs instanceof CollectionDatasource) {
                 CollectionDatasource parentCollectionDs = (CollectionDatasource) parentDs;
                 for (Entity item : itemsToCreate) {
-                    parentCollectionDs.addItem(item);
+                    if (parentCollectionDs.containsItem(item.getId())) {
+                        parentCollectionDs.modifyItem(item);
+                    } else {
+                        parentCollectionDs.addItem(item);
+                    }
                 }
                 for (Entity item : itemsToUpdate) {
                     parentCollectionDs.modifyItem(item);


### PR DESCRIPTION
How to reproduce:
1. Create a screen with datasource that contains nested collection datasource
```
<dsContext>
    <collectionDatasource id="foosDs">
        <collectionDatasource id=barsDs/>
    </collectionDatasource>
</dsContext>
```
2. Create a screen to edit master datasource with nested entities
```
<dsContext>
    <datasource id="fooDs">
        <collectionDatasource id=barsDs/>
    </datasource>
</dsContext>
```
3. Open the first screen and add some nested entities without committing data
4. Open second screen from the first with the master datasource as parent to root datasource
```
openEditor(foosDs.getItem(), WindowManager.OpenType.DIALOG, ImmutableMap.of(), foosDs );
```
5. Close without editing
6. There are duplicated new entities on the first screen.