### PR TITLE
Removed creation of embedded entities in CreateAction

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/components/actions/CreateAction.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/actions/CreateAction.java
@@ -211,17 +211,6 @@ public class CreateAction extends BaseAction implements Action.HasOpenType, Acti
 
         final Entity item = dataservice.newInstance(datasource.getMetaClass());
 
-        // instantiate embedded fields
-        Collection<MetaProperty> properties = datasource.getMetaClass().getProperties();
-        for (MetaProperty property : properties) {
-            if (!property.isReadOnly() && metadata.getTools().isEmbedded(property)) {
-                if (item.getValue(property.getName()) == null) {
-                    Entity defaultEmbeddedInstance = dataservice.newInstance(property.getRange().asClass());
-                    item.setValue(property.getName(), defaultEmbeddedInstance);
-                }
-            }
-        }
-
         if (target instanceof Tree) {
             String hierarchyProperty = ((Tree) target).getHierarchyProperty();
 


### PR DESCRIPTION
There is creation of embedded entities in `CreateAction`. But they are already created in `com.haulmont.cuba.core.sys.MetadataImpl#createEmbedded` with `EmbeddedParameters` annotation taken into account.