### PR TITLE
Ability to listen collection ds by super class listener

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/data/CollectionDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/CollectionDatasource.java
@@ -475,9 +475,9 @@ public interface CollectionDatasource<T extends Entity<K>, K> extends Datasource
         /**
          * Enclosed collection changed.
          */
-        void collectionChanged(CollectionChangeEvent<T, K> e);
+        void collectionChanged(CollectionChangeEvent<? extends T, K> e);
     }
 
-    void addCollectionChangeListener(CollectionChangeListener<T, K> listener);
-    void removeCollectionChangeListener(CollectionChangeListener<T, K> listener);
+    void addCollectionChangeListener(CollectionChangeListener<? super T, K> listener);
+    void removeCollectionChangeListener(CollectionChangeListener<? super T, K> listener);
 }

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/AbstractCollectionDatasource.java
@@ -700,12 +700,12 @@ public abstract class AbstractCollectionDatasource<T extends Entity<K>, K>
     }
 
     @Override
-    public void addCollectionChangeListener(CollectionChangeListener<T, K> listener) {
+    public void addCollectionChangeListener(CollectionChangeListener<? super T, K> listener) {
         getEventRouter().addListener(CollectionChangeListener.class, listener);
     }
 
     @Override
-    public void removeCollectionChangeListener(CollectionChangeListener<T, K> listener) {
+    public void removeCollectionChangeListener(CollectionChangeListener<? super T, K> listener) {
         getEventRouter().removeListener(CollectionChangeListener.class, listener);
     }
 

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/CollectionPropertyDatasourceImpl.java
@@ -61,7 +61,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
 
     protected boolean doNotModify;
 
-    protected List<CollectionChangeListener<T, K>> collectionChangeListeners;
+    protected List<CollectionChangeListener<? super T, K>> collectionChangeListeners;
 
     protected AggregatableDelegate<K> aggregatableDelegate = new AggregatableDelegate<K>() {
         @Override
@@ -730,7 +730,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
     }
 
     @Override
-    public void addCollectionChangeListener(CollectionChangeListener<T, K> listener) {
+    public void addCollectionChangeListener(CollectionChangeListener<? super T, K> listener) {
         Preconditions.checkNotNullArgument(listener, "listener cannot be null");
 
         if (collectionChangeListeners == null) {
@@ -742,7 +742,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
     }
 
     @Override
-    public void removeCollectionChangeListener(CollectionChangeListener<T, K> listener) {
+    public void removeCollectionChangeListener(CollectionChangeListener<? super T, K> listener) {
         if (collectionChangeListeners != null) {
             collectionChangeListeners.remove(listener);
         }
@@ -816,7 +816,7 @@ public class CollectionPropertyDatasourceImpl<T extends Entity<K>, K>
         if (collectionChangeListeners != null && !collectionChangeListeners.isEmpty()) {
             CollectionChangeEvent<T, K> event = new CollectionChangeEvent<>(this, operation, items);
 
-            for (CollectionChangeListener<T, K> listener : new ArrayList<>(collectionChangeListeners)) {
+            for (CollectionChangeListener<? super T, K> listener : new ArrayList<>(collectionChangeListeners)) {
                 listener.collectionChanged(event);
             }
         }


### PR DESCRIPTION
Suppose we have such model:
class Car extends Entity;
class Truck extends Car;
class SportCar extends Car;

And on gui module we have:
 "trucksDs" is a CollectionDatasource of entity Truck 
 "sportCarsDs" is a CollectionDatasource of entity SportCar 
and "carsCollectionChangeListener" is a CollectionChangeListener of Car to listen any cars datasources

I can not add carsCollectionChangeListener to trucksDs or sportCarsDs:
sportCarsDs.addCollectionChangeListener(carsCollectionChangeListener);