### PR TITLE
Fluent interface to DataManager

### DIFF
--- a/modules/core/test/com/haulmont/cuba/core/global/FluentLoaderTestAccess.java
+++ b/modules/core/test/com/haulmont/cuba/core/global/FluentLoaderTestAccess.java
@@ -29,4 +29,12 @@ public class FluentLoaderTestAccess {
     public static LoadContext createLoadContext(FluentLoader.ByQuery loader) {
         return loader.createLoadContext();
     }
+
+    public static ValueLoadContext createLoadContext(AbstractFluentValueLoader loader) {
+        return loader.createLoadContext();
+    }
+
+    public static Object castValue(FluentValueLoader loader, Object value) {
+        return loader.castValue(value);
+    }
 }

--- a/modules/core/test/com/haulmont/cuba/core/global/FluentLoaderTestAccess.java
+++ b/modules/core/test/com/haulmont/cuba/core/global/FluentLoaderTestAccess.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.core.global;
+
+public class FluentLoaderTestAccess {
+
+    public static LoadContext createLoadContext(FluentLoader loader) {
+        return loader.createLoadContext();
+    }
+
+    public static LoadContext createLoadContext(FluentLoader.ById loader) {
+        return loader.createLoadContext();
+    }
+
+    public static LoadContext createLoadContext(FluentLoader.ByQuery loader) {
+        return loader.createLoadContext();
+    }
+}

--- a/modules/core/test/spec/cuba/core/data_manager/FluentLoaderTest.groovy
+++ b/modules/core/test/spec/cuba/core/data_manager/FluentLoaderTest.groovy
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spec.cuba.core.data_manager
+
+import com.haulmont.cuba.core.global.AppBeans
+import com.haulmont.cuba.core.global.DataManager
+import com.haulmont.cuba.core.global.FluentLoaderTestAccess
+import com.haulmont.cuba.core.global.LoadContext
+import com.haulmont.cuba.core.global.TemporalValue
+import com.haulmont.cuba.core.global.View
+import com.haulmont.cuba.core.global.ViewRepository
+import com.haulmont.cuba.testmodel.sales.Customer
+import com.haulmont.cuba.testsupport.TestContainer
+import org.junit.ClassRule
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.persistence.TemporalType
+
+class FluentLoaderTest extends Specification {
+
+    @Shared @ClassRule
+    public TestContainer cont = TestContainer.Common.INSTANCE
+
+    private DataManager dataManager
+    private ViewRepository viewRepository
+    private View baseView
+    private customer
+    private UUID customerId
+
+    void setup() {
+        dataManager = AppBeans.get(DataManager)
+        viewRepository = AppBeans.get(ViewRepository)
+        baseView = viewRepository.getView(Customer, '_base')
+
+        customer = cont.metadata().create(Customer)
+        customer.name = 'Smith'
+        customerId = customer.id
+        dataManager.commit(customer)
+    }
+
+    void cleanup() {
+        cont.deleteRecord(customer)
+    }
+
+    def "example usage"() {
+
+        expect:
+
+        // load all
+
+        dataManager.load(Customer).list() instanceof List
+        dataManager.load(Customer).one() == customer
+        dataManager.load(Customer).optional() == Optional.of(customer)
+
+        dataManager.load(Customer).view('_base').list() instanceof List
+        dataManager.load(Customer).view(baseView).list() instanceof List
+
+        // load by id
+
+        dataManager.load(Customer).id(customerId).one() == customer
+        dataManager.load(Customer).id(customerId).optional() == Optional.of(customer)
+
+        dataManager.load(Customer).id(customerId).view('_base').one() == customer
+        dataManager.load(Customer).id(customerId).view(baseView).one() == customer
+
+        // load by query
+
+        dataManager.load(Customer).query('select c from test$Customer c').list() instanceof List
+        dataManager.load(Customer).query('select c from test$Customer c').one() == customer
+        dataManager.load(Customer).query('select c from test$Customer c').optional() == Optional.of(customer)
+
+        dataManager.load(Customer).query('select c from test$Customer c where c.name = :n')
+                .parameter('n', 'Smith')
+                .list() instanceof List
+
+        dataManager.load(Customer).query('select c from test$Customer c where c.name = :n')
+                .parameter('n', 'Smith')
+                .one() == customer
+
+        dataManager.load(Customer).query('select c from test$Customer c where c.name = :n')
+                .parameter('n', 'Smith')
+                .cacheable(true)
+                .list() instanceof List
+
+        dataManager.load(Customer).query('select c from test$Customer c where c.name = :n')
+                .parameter('n', 'Smith')
+                .firstResult(10)
+                .maxResults(100)
+                .list() instanceof List
+    }
+
+    def "test LoadContext when loading all"() {
+        def loader
+        LoadContext loadContext
+
+        when:
+
+        loader = dataManager.load(Customer)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.metaClass == 'test$Customer'
+        loadContext.query.queryString == 'select e from test$Customer e'
+        loadContext.softDeletion
+        !loadContext.query.cacheable
+
+        when:
+
+        loader = dataManager.load(Customer).softDeletion(false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        !loadContext.softDeletion
+
+        when:
+
+        loader = dataManager.load(Customer).view('_base')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.view == baseView
+
+        when:
+
+        loader = dataManager.load(Customer).view(baseView)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.view == baseView
+    }
+
+
+    def "test LoadContext when loading by id"() {
+        def loader
+        LoadContext loadContext
+
+        when:
+
+        loader = dataManager.load(Customer).id(customer.id)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.id == customerId
+        loadContext.softDeletion
+
+        when:
+
+        loader = dataManager.load(Customer).id(customer.id).softDeletion(false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        !loadContext.softDeletion
+
+        when:
+
+        loader = dataManager.load(Customer).id(customer.id).view('_base')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.view == baseView
+
+        when:
+
+        loader = dataManager.load(Customer).id(customer.id).view(baseView)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.view == baseView
+    }
+
+    def "test LoadContext when loading by query"() {
+        def loader
+        LoadContext loadContext
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.queryString == 'select c from test$Customer c'
+        loadContext.id == null
+        loadContext.softDeletion
+        !loadContext.query.cacheable
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c where name = :n')
+            .parameter('n', 'Smith')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters['n'] == 'Smith'
+        loadContext.query.noConversionParams == null
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c where name = :n')
+            .parameter('n', 'Smith', false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters['n'] == 'Smith'
+        loadContext.query.noConversionParams[0] == 'n'
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c where createTs >= :c')
+            .parameter('c', new Date(), TemporalType.DATE)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters['c'] instanceof TemporalValue
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c').cacheable(true)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.cacheable
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c').softDeletion(false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        !loadContext.softDeletion
+    }
+}

--- a/modules/core/test/spec/cuba/core/data_manager/FluentLoaderTest.groovy
+++ b/modules/core/test/spec/cuba/core/data_manager/FluentLoaderTest.groovy
@@ -57,7 +57,7 @@ class FluentLoaderTest extends Specification {
         cont.deleteRecord(customer)
     }
 
-    def "example usage"() {
+    def "usage examples"() {
 
         expect:
 
@@ -256,5 +256,17 @@ class FluentLoaderTest extends Specification {
         then:
 
         !loadContext.softDeletion
+
+        when:
+
+        loader = dataManager.load(Customer).query('select c from test$Customer c')
+            .firstResult(10)
+            .maxResults(100)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.firstResult == 10
+        loadContext.query.maxResults == 100
     }
 }

--- a/modules/core/test/spec/cuba/core/data_manager/FluentValueLoaderTest.groovy
+++ b/modules/core/test/spec/cuba/core/data_manager/FluentValueLoaderTest.groovy
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spec.cuba.core.data_manager
+
+import com.haulmont.cuba.core.entity.KeyValueEntity
+import com.haulmont.cuba.core.global.AppBeans
+import com.haulmont.cuba.core.global.DataManager
+import com.haulmont.cuba.core.global.FluentLoaderTestAccess
+import com.haulmont.cuba.core.global.FluentValueLoader
+import com.haulmont.cuba.core.global.Stores
+import com.haulmont.cuba.core.global.TemporalValue
+import com.haulmont.cuba.core.global.ValueLoadContext
+import com.haulmont.cuba.testmodel.sales.Customer
+import com.haulmont.cuba.testmodel.sales.Status
+import com.haulmont.cuba.testsupport.TestContainer
+import org.junit.ClassRule
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.persistence.TemporalType
+
+class FluentValueLoaderTest extends Specification {
+
+    @Shared @ClassRule
+    public TestContainer cont = TestContainer.Common.INSTANCE
+
+    private DataManager dataManager
+    private customer
+    private UUID customerId
+
+    void setup() {
+        dataManager = AppBeans.get(DataManager)
+        customer = cont.metadata().create(Customer)
+        customer.name = 'Smith'
+        customer.status = Status.OK
+        customerId = customer.id
+        dataManager.commit(customer)
+    }
+
+    void cleanup() {
+        cont.deleteRecord(customer)
+    }
+
+    def "usage examples"() {
+
+        List<KeyValueEntity> list
+        KeyValueEntity one
+        Optional<KeyValueEntity> optional
+
+        // Loading multiple values wrapped in KeyValueEntity
+
+        when:
+
+        list = dataManager.loadValues('select c.name from test$Customer c')
+                .property('custName')
+                .list()
+
+        one = dataManager.loadValues('select c.name from test$Customer c')
+                .property('custName')
+                .one()
+
+        optional = dataManager.loadValues('select c.name from test$Customer c')
+                .property('custName')
+                .optional()
+
+        then:
+
+        list[0].getValue('custName') == 'Smith'
+        one.getValue('custName') == 'Smith'
+        optional.get().getValue('custName') == 'Smith'
+
+        when:
+
+        list = dataManager.loadValues('select c.name, c.status from test$Customer c where c.name = :n')
+                .properties('custName', 'custStatus')
+                .parameter('n', 'Smith')
+                .list()
+
+        then:
+
+        list[0].getValue('custName') == 'Smith'
+        list[0].getValue('custStatus') == Status.OK.getId()
+
+        // Loading a single value
+
+        when:
+
+        List<String> names = dataManager.loadValue('select c.name from test$Customer c', String).list()
+
+        String name = dataManager.loadValue('select c.name from test$Customer c where c.id = :id', String)
+                .parameter('id', customerId)
+                .one()
+
+        Optional<String> optName = dataManager.loadValue('select c.name from test$Customer c where c.id = :id', String)
+                .parameter('id', customerId)
+                .optional()
+
+        then:
+
+        names[0] == 'Smith'
+        name == 'Smith'
+        optName.get() == 'Smith'
+
+        when:
+
+        Long count = dataManager.loadValue('select count(c) from test$Customer c', Long).one()
+
+        then:
+
+        count == 1
+
+        // The provided number value type can be different from the real type returned by the query. In the example
+        // below, 'count(c)' is of Long type, but it is returned as Integer
+
+        when:
+
+        Object intCount = dataManager.loadValue('select count(c) from test$Customer c', Integer).one()
+
+        then:
+
+        intCount instanceof Integer
+        intCount == 1
+    }
+
+    def "test ValueLoadContext"() {
+        def loader
+        ValueLoadContext loadContext
+
+        when:
+
+        loader = dataManager.loadValues('select c.name from test$Customer c')
+                .property('name')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.queryString == 'select c.name from test$Customer c'
+        loadContext.storeName == Stores.MAIN
+        loadContext.softDeletion
+        loadContext.properties == ['name']
+
+        when:
+
+        loader = dataManager.loadValues('select c.name from test$Customer c where name = :n')
+                .parameter('n', 'Smith')
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters == ['n': 'Smith']
+        loadContext.query.noConversionParams == null
+
+        when:
+
+        loader = dataManager.loadValues('select c.name from test$Customer c where name = :n')
+                .parameter('n', 'Smith', false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters == ['n': 'Smith']
+        loadContext.query.noConversionParams[0] == 'n'
+
+        when:
+
+        loader = dataManager.loadValues('select.name c from test$Customer c where createTs >= :c')
+                .parameter('c', new Date(), TemporalType.DATE)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.parameters['c'] instanceof TemporalValue
+
+        when:
+
+        loader = dataManager.loadValues('select c.name from test$Customer c').softDeletion(false)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        !loadContext.softDeletion
+
+        when:
+
+        loader = dataManager.loadValues('select c.name from test$Customer c')
+                .firstResult(10)
+                .maxResults(100)
+        loadContext = FluentLoaderTestAccess.createLoadContext(loader)
+
+        then:
+
+        loadContext.query.firstResult == 10
+        loadContext.query.maxResults == 100
+    }
+
+    def "test casting number values"() {
+
+        when:
+
+        FluentValueLoader<Integer> intLoader = dataManager.loadValue('select xyz', Integer)
+
+        then:
+
+        FluentLoaderTestAccess.castValue(intLoader, Long.valueOf(10)).equals(10)
+        FluentLoaderTestAccess.castValue(intLoader, Short.valueOf((short) 10)).equals(10)
+        FluentLoaderTestAccess.castValue(intLoader, Double.valueOf(10.123)).equals(10)
+        FluentLoaderTestAccess.castValue(intLoader, Float.valueOf(10.123)).equals(10)
+        FluentLoaderTestAccess.castValue(intLoader, BigDecimal.valueOf(10.123)).equals(10)
+        FluentLoaderTestAccess.castValue(intLoader, BigInteger.valueOf(10)).equals(10)
+
+        when:
+
+        FluentValueLoader<Long> longLoader = dataManager.loadValue('select xyz', Long)
+
+        then:
+
+        FluentLoaderTestAccess.castValue(longLoader, Integer.valueOf(10)).equals(10L)
+        FluentLoaderTestAccess.castValue(longLoader, Short.valueOf((short) 10)).equals(10L)
+        FluentLoaderTestAccess.castValue(longLoader, Double.valueOf(10.123)).equals(10L)
+        FluentLoaderTestAccess.castValue(longLoader, Float.valueOf(10.123)).equals(10L)
+        FluentLoaderTestAccess.castValue(longLoader, BigDecimal.valueOf(10.123)).equals(10L)
+        FluentLoaderTestAccess.castValue(longLoader, BigInteger.valueOf(10)).equals(10L)
+
+        when:
+
+        FluentValueLoader<BigDecimal> decimalLoader = dataManager.loadValue('select xyz', BigDecimal)
+
+        then:
+
+        FluentLoaderTestAccess.castValue(decimalLoader, 10).equals(BigDecimal.valueOf(10.0))
+        FluentLoaderTestAccess.castValue(decimalLoader, 10L).equals(BigDecimal.valueOf(10.0))
+        FluentLoaderTestAccess.castValue(decimalLoader, (short) 10).equals(BigDecimal.valueOf(10.0))
+        FluentLoaderTestAccess.castValue(decimalLoader, 10.123).equals(BigDecimal.valueOf(10.123))
+        FluentLoaderTestAccess.castValue(decimalLoader, 10.123F) instanceof BigDecimal
+        FluentLoaderTestAccess.castValue(decimalLoader, BigInteger.valueOf(10)).equals(BigDecimal.valueOf(10.0))
+
+        when:
+
+        FluentValueLoader<Double> doubleLoader = dataManager.loadValue('select xyz', Double)
+
+        then:
+
+        FluentLoaderTestAccess.castValue(doubleLoader, 10) instanceof Double
+        FluentLoaderTestAccess.castValue(doubleLoader, 10L) instanceof Double
+        FluentLoaderTestAccess.castValue(doubleLoader, (short) 10) instanceof Double
+        FluentLoaderTestAccess.castValue(doubleLoader, 10.123F) instanceof Double
+        FluentLoaderTestAccess.castValue(doubleLoader, BigDecimal.valueOf(10.123)) instanceof Double
+        FluentLoaderTestAccess.castValue(doubleLoader, BigInteger.valueOf(10)) instanceof Double
+    }
+
+}

--- a/modules/global/src/com/haulmont/cuba/core/global/AbstractFluentValueLoader.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/AbstractFluentValueLoader.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.core.global;
+
+import javax.persistence.TemporalType;
+import java.util.*;
+
+class AbstractFluentValueLoader {
+
+    protected DataManager dataManager;
+
+    private String store;
+    private String queryString;
+    private boolean softDeletion = true;
+    private Map<String, Object> parameters = new HashMap<>();
+    private Set<String> noConversionParams = new HashSet<>();
+    private int firstResult;
+    private int maxResults;
+
+    AbstractFluentValueLoader(String queryString, DataManager dataManager) {
+        this.queryString = queryString;
+        this.dataManager = dataManager;
+    }
+
+    protected ValueLoadContext createLoadContext() {
+        ValueLoadContext loadContext = ValueLoadContext.create();
+        if (store != null)
+            loadContext.setStoreName(store);
+        loadContext.setSoftDeletion(softDeletion);
+
+        ValueLoadContext.Query query = ValueLoadContext.createQuery(queryString);
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            if (noConversionParams.contains(entry.getKey()))
+                query.setParameter(entry.getKey(), entry.getValue(), false);
+            else
+                query.setParameter(entry.getKey(), entry.getValue());
+        }
+        loadContext.setQuery(query);
+
+        loadContext.getQuery().setFirstResult(firstResult);
+        loadContext.getQuery().setMaxResults(maxResults);
+
+        return loadContext;
+    }
+
+    /**
+     * Sets DataStore name.
+     */
+    public AbstractFluentValueLoader store(String store) {
+        this.store = store;
+        return this;
+    }
+
+    /**
+     * Sets soft deletion. The soft deletion is true by default.
+     */
+    public AbstractFluentValueLoader softDeletion(boolean softDeletion) {
+        this.softDeletion = softDeletion;
+        return this;
+    }
+
+    /**
+     * Sets value for a query parameter.
+
+     * @param name  parameter name
+     * @param value parameter value
+     */
+    public AbstractFluentValueLoader parameter(String name, Object value) {
+        parameters.put(name, value);
+        return this;
+    }
+
+    /**
+     * Sets value for a parameter of {@code java.util.Date} type.
+
+     * @param name  parameter name
+     * @param value parameter value
+     * @param temporalType  how to interpret the value
+     */
+    public AbstractFluentValueLoader parameter(String name, Date value, TemporalType temporalType) {
+        parameters.put(name, new TemporalValue(value, temporalType));
+        return this;
+    }
+
+    /**
+     * Sets value for a query parameter.
+
+     * @param name  parameter name
+     * @param value parameter value
+     * @param implicitConversion whether to do parameter value conversions, e.g. convert an entity to its ID
+     */
+    public AbstractFluentValueLoader parameter(String name, Object value, boolean implicitConversion) {
+        parameters.put(name, value);
+        if (!implicitConversion) {
+            noConversionParams.add(name);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the map of query parameters.
+     */
+    public AbstractFluentValueLoader setParameters(Map<String, Object> parameters) {
+        this.parameters.putAll(parameters);
+        return this;
+    }
+
+    /**
+     * Sets results offset.
+     */
+    public AbstractFluentValueLoader firstResult(int firstResult) {
+        this.firstResult = firstResult;
+        return this;
+    }
+
+    /**
+     * Sets results limit.
+     */
+    public AbstractFluentValueLoader maxResults(int maxResults) {
+        this.maxResults = maxResults;
+        return this;
+    }
+}

--- a/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
@@ -178,4 +178,46 @@ public interface DataManager {
     default <E extends Entity<K>, K> FluentLoader<E, K> load(Class<E> entityClass) {
         return new FluentLoader<>(entityClass, this);
     }
+
+    /**
+     * Entry point to the fluent API for loading scalar values.
+     * <p>
+     * Usage examples:
+     * <pre>
+     * List&lt;KeyValueEntity&gt; customerDataList = dataManager.loadValues(
+     *          "select c.name, c.status from sample$Customer c where c.name = :n")
+     *      .properties("custName", "custStatus")
+     *      .parameter("name", "Smith")
+     *      .list();
+     *
+     * KeyValueEntity customerData = dataManager.loadValues(
+     *          "select c.name, count(c) from sample$Customer c group by c.name")
+     *      .properties("custName", "custCount")
+     *      .one();
+     * </pre>
+     * @param queryString   query string
+     */
+    default FluentValuesLoader loadValues(String queryString) {
+        return new FluentValuesLoader(queryString, this);
+    }
+
+    /**
+     * Entry point to the fluent API for loading a single scalar value.
+     * <p>
+     * Terminal methods of this API ({@code list}, {@code one} and {@code optional}) return a single value
+     * from the first column of the query result set. You should provide the expected type of this value in the second
+     * parameter. Number types will be converted appropriately, so for example if the query returns Long and you
+     * expected Integer, the returned value will be automatically converted from Long to Integer.
+     * <p>
+     * Usage examples:
+     * <pre>
+     * Long customerCount = dataManager.loadValue(
+     *          "select count(c) from sample$Customer c", Long.class).one();
+     * </pre>
+     * @param queryString   query string
+     * @param valueClass    type of the returning value
+     */
+    default <T> FluentValueLoader<T> loadValue(String queryString, Class<T> valueClass) {
+        return new FluentValueLoader<>(queryString, valueClass, this);
+    }
 }

--- a/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
@@ -159,4 +159,23 @@ public interface DataManager {
      * </pre>
      */
     DataManager secure();
+
+    /**
+     * Entry point to the fluent API for loading entities.
+     * <p>
+     * Usage examples:
+     * <pre>
+     * Customer customer = dataManager.load(Customer.class).id(someId).one();
+     *
+     * List&lt;Customer&gt; customers = dataManager.load(Customer.class)
+     *      .query("select c from sample$Customer c where c.name = :name")
+     *      .parameter("name", "Smith")
+     *      .view("customer-view")
+     *      .list();
+     * </pre>
+     * @param entityClass   class of entity that needs to be loaded
+     */
+    default <E extends Entity<K>, K> FluentLoader<E, K> load(Class<E> entityClass) {
+        return new FluentLoader<>(entityClass, this);
+    }
 }

--- a/modules/global/src/com/haulmont/cuba/core/global/FluentLoader.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/FluentLoader.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.core.global;
+
+import com.google.common.base.Strings;
+import com.haulmont.bali.util.Preconditions;
+import com.haulmont.cuba.core.entity.Entity;
+
+import javax.persistence.TemporalType;
+import java.util.*;
+
+public class FluentLoader<E extends Entity<K>, K> {
+
+    private Class<E> entityClass;
+
+    private DataManager dataManager;
+
+    private View view;
+    private String viewName;
+    private boolean softDeletion = true;
+
+    public FluentLoader(Class<E> entityClass, DataManager dataManager) {
+        this.entityClass = entityClass;
+        this.dataManager = dataManager;
+    }
+
+    LoadContext<E> createLoadContext() {
+        LoadContext<E> loadContext = LoadContext.create(entityClass);
+        initCommonLoadContextParameters(loadContext);
+
+        String entityName = AppBeans.get(Metadata.class).getClassNN(entityClass).getName();
+        String queryString = String.format("select e from %s e", entityName);
+        loadContext.setQuery(LoadContext.createQuery(queryString));
+
+        return loadContext;
+    }
+
+    private void initCommonLoadContextParameters(LoadContext<E> loadContext) {
+        if (view != null)
+            loadContext.setView(view);
+        else if (!Strings.isNullOrEmpty(viewName))
+            loadContext.setView(viewName);
+
+        loadContext.setSoftDeletion(softDeletion);
+    }
+
+    /**
+     * Loads a list of entities.
+     */
+    public List<E> list() {
+        LoadContext<E> loadContext = createLoadContext();
+        return dataManager.loadList(loadContext);
+    }
+
+    /**
+     * Loads a single instance and wraps it in Optional.
+     */
+    public Optional<E> optional() {
+        LoadContext<E> loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        return Optional.ofNullable(dataManager.load(loadContext));
+    }
+
+    /**
+     * Loads a single instance.
+     *
+     * @throws IllegalStateException if nothing was loaded
+     */
+    public E one() {
+        LoadContext<E> loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        E entity = dataManager.load(loadContext);
+        if (entity != null)
+            return entity;
+        else
+            throw new IllegalStateException("No results");
+    }
+
+    /**
+     * Sets a view.
+     */
+    public FluentLoader<E, K> view(View view) {
+        this.view = view;
+        return this;
+    }
+
+    /**
+     * Sets a view by name.
+     */
+    public FluentLoader<E, K> view(String viewName) {
+        this.viewName = viewName;
+        return this;
+    }
+
+    /**
+     * Sets soft deletion. The soft deletion is true by default.
+     */
+    public FluentLoader<E, K> softDeletion(boolean softDeletion) {
+        this.softDeletion = softDeletion;
+        return this;
+    }
+
+    /**
+     * Sets the entity identifier.
+     */
+    public ById id(K id) {
+        return new ById(id);
+    }
+
+    /**
+     * Sets the query text.
+     */
+    public ByQuery query(String queryString) {
+        return new ByQuery(queryString);
+    }
+
+    public class ById {
+
+        private Object id;
+
+        public ById(Object id) {
+            this.id = id;
+        }
+
+        LoadContext<E> createLoadContext() {
+            LoadContext<E> loadContext = LoadContext.create(entityClass).setId(id);
+            initCommonLoadContextParameters(loadContext);
+            return loadContext;
+        }
+
+        /**
+         * Loads a single instance and wraps it in Optional.
+         */
+        public Optional<E> optional() {
+            LoadContext<E> loadContext = createLoadContext();
+            return Optional.ofNullable(dataManager.load(loadContext));
+        }
+
+        /**
+         * Loads a single instance.
+         *
+         * @throws IllegalStateException if nothing was loaded
+         */
+        public E one() {
+            LoadContext<E> loadContext = createLoadContext();
+            E entity = dataManager.load(loadContext);
+            if (entity != null)
+                return entity;
+            else
+                throw new IllegalStateException("No results");
+        }
+
+        /**
+         * Sets a view.
+         */
+        public ById view(View view) {
+            FluentLoader.this.view = view;
+            return this;
+        }
+
+        /**
+         * Sets a view by name.
+         */
+        public ById view(String viewName) {
+            FluentLoader.this.viewName = viewName;
+            return this;
+        }
+
+        /**
+         * Sets soft deletion. The soft deletion is true by default.
+         */
+        public ById softDeletion(boolean softDeletion) {
+            FluentLoader.this.softDeletion = softDeletion;
+            return this;
+        }
+    }
+
+    public class ByQuery {
+
+        private String queryString;
+        private Map<String, Object> parameters = new HashMap<>();
+        private Set<String> noConversionParams = new HashSet<>();
+        private int firstResult;
+        private int maxResults;
+        private boolean cacheable;
+
+        public ByQuery(String queryString) {
+            Preconditions.checkNotEmptyString(queryString, "queryString is empty");
+            this.queryString = queryString;
+        }
+
+        LoadContext<E> createLoadContext() {
+            LoadContext<E> loadContext = LoadContext.create(entityClass);
+            initCommonLoadContextParameters(loadContext);
+
+            LoadContext.Query query = LoadContext.createQuery(queryString);
+            for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+                if (noConversionParams.contains(entry.getKey()))
+                    query.setParameter(entry.getKey(), entry.getValue(), false);
+                else
+                    query.setParameter(entry.getKey(), entry.getValue());
+            }
+            loadContext.setQuery(query);
+
+            loadContext.getQuery().setFirstResult(firstResult);
+            loadContext.getQuery().setMaxResults(maxResults);
+            loadContext.getQuery().setCacheable(cacheable);
+
+            return loadContext;
+        }
+
+        /**
+         * Loads a list of entities.
+         */
+        public List<E> list() {
+            LoadContext<E> loadContext = createLoadContext();
+            return dataManager.loadList(loadContext);
+        }
+
+        /**
+         * Loads a single instance and wraps it in Optional.
+         */
+        public Optional<E> optional() {
+            LoadContext<E> loadContext = createLoadContext();
+            return Optional.ofNullable(dataManager.load(loadContext));
+        }
+
+        /**
+         * Loads a single instance.
+         *
+         * @throws IllegalStateException if nothing was loaded
+         */
+        public E one() {
+            LoadContext<E> loadContext = createLoadContext();
+            E entity = dataManager.load(loadContext);
+            if (entity != null)
+                return entity;
+            else
+                throw new IllegalStateException("No results");
+        }
+
+        /**
+         * Sets a view.
+         */
+        public ByQuery view(View view) {
+            FluentLoader.this.view = view;
+            return this;
+        }
+
+        /**
+         * Sets a view by name.
+         */
+        public ByQuery view(String viewName) {
+            FluentLoader.this.viewName = viewName;
+            return this;
+        }
+
+        /**
+         * Sets soft deletion. The soft deletion is true by default.
+         */
+        public ByQuery softDeletion(boolean softDeletion) {
+            FluentLoader.this.softDeletion = softDeletion;
+            return this;
+        }
+
+        /**
+         * Sets value for a query parameter.
+
+         * @param name  parameter name
+         * @param value parameter value
+         */
+        public ByQuery parameter(String name, Object value) {
+            parameters.put(name, value);
+            return this;
+        }
+
+        /**
+         * Sets value for a parameter of {@code java.util.Date} type.
+
+         * @param name  parameter name
+         * @param value parameter value
+         * @param temporalType  how to interpret the value
+         */
+        public ByQuery parameter(String name, Date value, TemporalType temporalType) {
+            parameters.put(name, new TemporalValue(value, temporalType));
+            return this;
+        }
+
+        /**
+         * Sets value for a query parameter.
+
+         * @param name  parameter name
+         * @param value parameter value
+         * @param implicitConversion whether to do parameter value conversions, e.g. convert an entity to its ID
+         */
+        public ByQuery parameter(String name, Object value, boolean implicitConversion) {
+            parameters.put(name, value);
+            if (!implicitConversion) {
+                noConversionParams.add(name);
+            }
+            return this;
+        }
+
+        /**
+         * Sets results offset.
+         */
+        public ByQuery firstResult(int firstResult) {
+            this.firstResult = firstResult;
+            return this;
+        }
+
+        /**
+         * Sets results limit.
+         */
+        public ByQuery maxResults(int maxResults) {
+            this.maxResults = maxResults;
+            return this;
+        }
+
+        /**
+         * Indicates that the query results should be cached.
+         * By default, queries are not cached.
+         */
+        public ByQuery cacheable(boolean cacheable) {
+            this.cacheable = cacheable;
+            return this;
+        }
+    }
+}

--- a/modules/global/src/com/haulmont/cuba/core/global/FluentLoader.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/FluentLoader.java
@@ -33,7 +33,7 @@ public class FluentLoader<E extends Entity<K>, K> {
     private String viewName;
     private boolean softDeletion = true;
 
-    public FluentLoader(Class<E> entityClass, DataManager dataManager) {
+    FluentLoader(Class<E> entityClass, DataManager dataManager) {
         this.entityClass = entityClass;
         this.dataManager = dataManager;
     }
@@ -132,7 +132,7 @@ public class FluentLoader<E extends Entity<K>, K> {
 
         private Object id;
 
-        public ById(Object id) {
+        ById(Object id) {
             this.id = id;
         }
 
@@ -198,7 +198,7 @@ public class FluentLoader<E extends Entity<K>, K> {
         private int maxResults;
         private boolean cacheable;
 
-        public ByQuery(String queryString) {
+        ByQuery(String queryString) {
             Preconditions.checkNotEmptyString(queryString, "queryString is empty");
             this.queryString = queryString;
         }
@@ -312,6 +312,14 @@ public class FluentLoader<E extends Entity<K>, K> {
             if (!implicitConversion) {
                 noConversionParams.add(name);
             }
+            return this;
+        }
+
+        /**
+         * Sets the map of query parameters.
+         */
+        public ByQuery setParameters(Map<String, Object> parameters) {
+            this.parameters.putAll(parameters);
             return this;
         }
 

--- a/modules/global/src/com/haulmont/cuba/core/global/FluentValueLoader.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/FluentValueLoader.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.core.global;
+
+import com.haulmont.cuba.core.entity.KeyValueEntity;
+
+import javax.persistence.TemporalType;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FluentValueLoader<T> extends AbstractFluentValueLoader {
+
+    private final Class<T> valueClass;
+
+    private final static String PROP_NAME = "p1";
+
+    FluentValueLoader(String queryString, Class<T> valueClass, DataManager dataManager) {
+        super(queryString, dataManager);
+        this.valueClass = valueClass;
+    }
+
+    protected ValueLoadContext createLoadContext() {
+        ValueLoadContext loadContext = super.createLoadContext();
+        loadContext.addProperty(PROP_NAME);
+        return loadContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    T castValue(Object value) {
+        if (value != null && !value.getClass().equals(valueClass) && Number.class.isAssignableFrom(valueClass)) {
+            if (valueClass.equals(Integer.class)) {
+                return (T) Integer.valueOf(((Number) value).intValue());
+            }
+            if (valueClass.equals(Long.class)) {
+                return (T) Long.valueOf(((Number) value).longValue());
+            }
+            if (valueClass.equals(Double.class)) {
+                return (T) Double.valueOf(((Number) value).doubleValue());
+            }
+            if (valueClass.equals(Float.class)) {
+                return (T) Float.valueOf(((Number) value).floatValue());
+            }
+            if (valueClass.equals(Short.class)) {
+                return (T) Short.valueOf(((Number) value).shortValue());
+            }
+            if (valueClass.equals(BigDecimal.class)) {
+                return (T) BigDecimal.valueOf(((Number) value).doubleValue());
+            }
+            if (valueClass.equals(BigInteger.class)) {
+                return (T) BigInteger.valueOf(((Number) value).longValue());
+            }
+        }
+        return (T) value;
+    }
+
+    /**
+     * Loads a list of entities.
+     */
+    public List<T> list() {
+        ValueLoadContext loadContext = createLoadContext();
+        return dataManager.loadValues(loadContext).stream()
+                .map(e -> castValue(e.getValue(PROP_NAME)))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads a single instance and wraps it in Optional.
+     */
+    public Optional<T> optional() {
+        ValueLoadContext loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        List<KeyValueEntity> list = dataManager.loadValues(loadContext);
+        return list.isEmpty() ? Optional.empty() : Optional.ofNullable(castValue(list.get(0).getValue(PROP_NAME)));
+    }
+
+    /**
+     * Loads a single instance.
+     *
+     * @throws IllegalStateException if nothing was loaded
+     */
+    public T one() {
+        ValueLoadContext loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        List<KeyValueEntity> list = dataManager.loadValues(loadContext);
+        if (!list.isEmpty())
+            return castValue(list.get(0).getValue(PROP_NAME));
+        else
+            throw new IllegalStateException("No results");
+    }
+
+    @Override
+    public FluentValueLoader store(String store) {
+        super.store(store);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader softDeletion(boolean softDeletion) {
+        super.softDeletion(softDeletion);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader parameter(String name, Object value) {
+        super.parameter(name, value);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader parameter(String name, Date value, TemporalType temporalType) {
+        super.parameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader parameter(String name, Object value, boolean implicitConversion) {
+        super.parameter(name, value, implicitConversion);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader setParameters(Map<String, Object> parameters) {
+        super.setParameters(parameters);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader firstResult(int firstResult) {
+        super.firstResult(firstResult);
+        return this;
+    }
+
+    @Override
+    public FluentValueLoader maxResults(int maxResults) {
+        super.maxResults(maxResults);
+        return this;
+    }
+}

--- a/modules/global/src/com/haulmont/cuba/core/global/FluentValuesLoader.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/FluentValuesLoader.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2018 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.core.global;
+
+import com.haulmont.cuba.core.entity.KeyValueEntity;
+
+import javax.persistence.TemporalType;
+import java.util.*;
+
+public class FluentValuesLoader extends AbstractFluentValueLoader {
+
+    private List<String> properties = new ArrayList<>();
+
+    FluentValuesLoader(String queryString, DataManager dataManager) {
+        super(queryString, dataManager);
+    }
+
+    protected ValueLoadContext createLoadContext() {
+        ValueLoadContext loadContext = super.createLoadContext();
+        loadContext.setProperties(properties);
+        return loadContext;
+    }
+
+    /**
+     * Loads a list of entities.
+     */
+    public List<KeyValueEntity> list() {
+        ValueLoadContext loadContext = createLoadContext();
+        return dataManager.loadValues(loadContext);
+    }
+
+    /**
+     * Loads a single instance and wraps it in Optional.
+     */
+    public Optional<KeyValueEntity> optional() {
+        ValueLoadContext loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        List<KeyValueEntity> list = dataManager.loadValues(loadContext);
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    }
+
+    /**
+     * Loads a single instance.
+     *
+     * @throws IllegalStateException if nothing was loaded
+     */
+    public KeyValueEntity one() {
+        ValueLoadContext loadContext = createLoadContext();
+        loadContext.getQuery().setMaxResults(1);
+        List<KeyValueEntity> list = dataManager.loadValues(loadContext);
+        if (!list.isEmpty())
+            return list.get(0);
+        else
+            throw new IllegalStateException("No results");
+    }
+
+    /**
+     * Adds a key of a returned key-value pair. The sequence of adding properties must conform to the sequence of
+     * result fields in the query "select" clause.
+     * <p>For example, if the query is <code>select e.id, e.name from sample$Customer</code>
+     * and you executed <code>property("customerId").property("customerName")</code>, the returned KeyValueEntity
+     * will contain customer identifiers in "customerId" property and names in "customerName" property.
+     */
+    public FluentValuesLoader property(String name) {
+        properties.add(name);
+        return this;
+    }
+
+    /**
+     * The same as invoking {@link #property(String)} multiple times.
+     */
+    public FluentValuesLoader properties(List<String> properties) {
+        this.properties.clear();
+        this.properties.addAll(properties);
+        return this;
+    }
+
+    /**
+     * The same as invoking {@link #property(String)} multiple times.
+     */
+    public FluentValuesLoader properties(String... properties) {
+        return properties(Arrays.asList(properties));
+    }
+
+    @Override
+    public FluentValuesLoader store(String store) {
+        super.store(store);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader softDeletion(boolean softDeletion) {
+        super.softDeletion(softDeletion);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader parameter(String name, Object value) {
+        super.parameter(name, value);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader parameter(String name, Date value, TemporalType temporalType) {
+        super.parameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader parameter(String name, Object value, boolean implicitConversion) {
+        super.parameter(name, value, implicitConversion);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader setParameters(Map<String, Object> parameters) {
+        super.setParameters(parameters);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader firstResult(int firstResult) {
+        super.firstResult(firstResult);
+        return this;
+    }
+
+    @Override
+    public FluentValuesLoader maxResults(int maxResults) {
+        super.maxResults(maxResults);
+        return this;
+    }
+}


### PR DESCRIPTION
More concise way to load entities with DataManager. See usage examples [here](https://github.com/cuba-platform/cuba/compare/feature/dm-fluent-loader?expand=1#diff-23ddf5b69fc7cbfc169a730fb26decdcR60).