### PR TITLE
REST API: view always null in get entity by id method

### DIFF
--- a/modules/rest-api/src/com/haulmont/restapi/service/EntitiesControllerManager.java
+++ b/modules/rest-api/src/com/haulmont/restapi/service/EntitiesControllerManager.java
@@ -115,7 +115,7 @@ public class EntitiesControllerManager {
 
         restControllerUtils.applyAttributesSecurity(entity);
 
-        String json = entitySerializationAPI.toJson(entity, null, serializationOptions.toArray(new EntitySerializationOption[0]));
+        String json = entitySerializationAPI.toJson(entity, ctx.getView(), serializationOptions.toArray(new EntitySerializationOption[0]));
         json = restControllerUtils.transformJsonIfRequired(entityName, modelVersion, JsonTransformationDirection.TO_VERSION, json);
         return json;
     }


### PR DESCRIPTION
Serialization to JSON in get entity by id method always performed with empty view regardless of query parameter value.