### PR TITLE
Adds the ability to specify aliases for datasources of frames

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/WindowManager.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/WindowManager.java
@@ -664,7 +664,7 @@ public abstract class WindowManager {
         }
 
         //noinspection UnnecessaryLocalVariable
-        DsContext dsContext = new DsContextLoader(dataSupplier).loadDatasources(element.element("dsContext"), null);
+        DsContext dsContext = new DsContextLoader(dataSupplier).loadDatasources(element.element("dsContext"), null, null);
         return dsContext;
     }
 

--- a/modules/gui/src/com/haulmont/cuba/gui/data/DsContext.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/DsContext.java
@@ -71,6 +71,13 @@ public interface DsContext {
     Collection<Datasource> getAll();
 
     /**
+     * Add alias for datasource.
+     * @param aliasDatasourceId     additional datasource id
+     * @param originalDatasourceId  original datasource id
+     */
+    void addAlias(String aliasDatasourceId, String originalDatasourceId);
+
+    /**
      * @return true if any contained datasource is modified
      */
     boolean isModified();

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/DsContextImpl.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/DsContextImpl.java
@@ -41,6 +41,7 @@ public class DsContextImpl implements DsContextImplementation {
 
     protected Map<String, Datasource> datasourceMap = new HashMap<>();
     protected Map<Datasource, Datasource> dependencies = new HashMap<>();
+    protected Map<String, String> aliasesMap = new HashMap<>();
 
     protected Metadata metadata;
 
@@ -507,6 +508,9 @@ public class DsContextImpl implements DsContextImplementation {
 
     @Override
     public Datasource get(String id) {
+        if (aliasesMap.containsKey(id)) {
+            id = aliasesMap.get(id);
+        }
         Preconditions.checkNotNullArgument(id, "Null datasource ID");
         Datasource ds = null;
         if (!id.contains(".")) {
@@ -539,6 +543,10 @@ public class DsContextImpl implements DsContextImplementation {
     @Override
     public Collection<Datasource> getAll() {
         return datasourceMap.values();
+    }
+
+    public void addAlias(String aliasDatasourceId, String originalDatasourceId) {
+        aliasesMap.put(aliasDatasourceId, originalDatasourceId);
     }
 
     @Override

--- a/modules/gui/src/com/haulmont/cuba/gui/window.xsd
+++ b/modules/gui/src/com/haulmont/cuba/gui/window.xsd
@@ -80,7 +80,7 @@
             </xs:simpleType>
         </xs:union>
     </xs:simpleType>
-    
+
     <xs:simpleType name="numericDatatypeEnum">
         <xs:union>
             <xs:simpleType>
@@ -2562,6 +2562,20 @@
     <xs:complexType name="frameContainer">
         <xs:complexContent>
             <xs:extension base="baseComponent">
+                <xs:sequence>
+                    <xs:element name="dsContext" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="alias" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attributeGroup ref="hasDatasourceProp"/>
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
                 <xs:attribute name="src" type="xs:string"/>
                 <xs:attribute name="screen" type="xs:string"/>
             </xs:extension>

--- a/modules/gui/src/com/haulmont/cuba/gui/window.xsd
+++ b/modules/gui/src/com/haulmont/cuba/gui/window.xsd
@@ -2563,16 +2563,10 @@
         <xs:complexContent>
             <xs:extension base="baseComponent">
                 <xs:sequence>
-                    <xs:element name="dsContext" minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="dsAlias" minOccurs="0" maxOccurs="unbounded">
                         <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="alias" minOccurs="0" maxOccurs="unbounded">
-                                    <xs:complexType>
-                                        <xs:attributeGroup ref="hasDatasourceProp"/>
-                                        <xs:attribute name="name" type="xs:string" use="required"/>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
+                            <xs:attributeGroup ref="hasDatasourceProp"/>
+                            <xs:attribute name="alias" type="xs:string" use="required"/>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/data/DsContextLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/data/DsContextLoader.java
@@ -36,6 +36,7 @@ import org.dom4j.Element;
 import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class DsContextLoader {
@@ -53,11 +54,14 @@ public class DsContextLoader {
         this.metadata = AppBeans.get(Metadata.NAME);
     }
 
-    public DsContext loadDatasources(@Nullable Element element,@Nullable DsContext parent) {
+    public DsContext loadDatasources(@Nullable Element element, @Nullable DsContext parent, Map<String, String> aliasesMap) {
         if (element == null) {
             context = new DsContextImpl(dataservice);
             if (parent != null)
                 context.setParent(parent);
+            if (aliasesMap != null) {
+                aliasesMap.forEach(context::addAlias);
+            }
             return context;
         }
 
@@ -78,6 +82,9 @@ public class DsContextLoader {
         }
         if (parent != null) {
             context.setParent(parent);
+        }
+        if (aliasesMap != null) {
+            aliasesMap.forEach(context::addAlias);
         }
 
         builder = DsBuilder.create(context);

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/ComponentLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/ComponentLoader.java
@@ -47,6 +47,8 @@ public interface ComponentLoader<T extends Component> {
         void addInitTask(InitTask task);
         void executeInitTasks();
 
+        Map<String, String> getAliasesMap();
+
         Frame getFrame();
         void setFrame(Frame frame);
 

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/ComponentLoaderContext.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/ComponentLoaderContext.java
@@ -23,6 +23,7 @@ import com.haulmont.cuba.gui.xml.layout.ComponentLoader;
 import groovy.lang.Binding;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +41,7 @@ public class ComponentLoaderContext implements ComponentLoader.Context {
     protected List<ComponentLoader.InitTask> initTasks = new ArrayList<>();
 
     protected Map<String, Object> parameters;
+    protected Map<String, String> aliasesMap = new HashMap<>();
 
     protected ComponentLoader.Context parent;
 
@@ -199,6 +201,11 @@ public class ComponentLoaderContext implements ComponentLoader.Context {
         if (context.getInitTasks().remove(task) && context.getParent() != null) {
             removeTask(task, (ComponentLoaderContext) context.getParent());
         }
+    }
+
+    @Override
+    public Map<String, String> getAliasesMap() {
+        return aliasesMap;
     }
 
     protected class TaskExecutor implements Runnable {

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
@@ -94,6 +94,8 @@ public class FrameComponentLoader extends ContainerLoader<Frame> {
         loadCaption(resultComponent, element);
         loadDescription(resultComponent, element);
 
+        loadAliases();
+
         if (context.getFrame() != null) {
             resultComponent.setFrame(context.getFrame());
         }
@@ -123,6 +125,22 @@ public class FrameComponentLoader extends ContainerLoader<Frame> {
         } finally {
             context.setCurrentFrameId(currentFrameId);
             loadDescriptorWatch.stop();
+        }
+    }
+
+    protected void loadAliases() {
+        Element dsAliases = element.element("dsContext");
+        if (dsAliases != null && frameLoader instanceof FrameLoader) {
+            ComponentLoaderContext frameLoaderInnerContext = ((FrameLoader) frameLoader).getInnerContext();
+            for (Object o : dsAliases.elements("alias")) {
+                if (o instanceof Element) {
+                    String aliasDatasourceId = ((Element) o).attributeValue("name");
+                    String originalDatasourceId = ((Element) o).attributeValue("datasource");
+                    if (StringUtils.isNotBlank(aliasDatasourceId) && StringUtils.isNotBlank(originalDatasourceId)) {
+                        frameLoaderInnerContext.getAliasesMap().put(aliasDatasourceId, originalDatasourceId);
+                    }
+                }
+            }
         }
     }
 }

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
@@ -130,11 +130,10 @@ public class FrameComponentLoader extends ContainerLoader<Frame> {
     }
 
     protected void loadAliases() {
-        Element dsAliases = element.element("dsContext");
-        if (dsAliases != null && frameLoader instanceof FrameLoader) {
+        if (frameLoader instanceof FrameLoader) {
             ComponentLoaderContext frameLoaderInnerContext = ((FrameLoader) frameLoader).getInnerContext();
-            for (Element aliasElement : Dom4j.elements(dsAliases, "alias")) {
-                    String aliasDatasourceId = aliasElement.attributeValue("name");
+            for (Element aliasElement : Dom4j.elements(element, "dsAlias")) {
+                    String aliasDatasourceId = aliasElement.attributeValue("alias");
                     String originalDatasourceId = aliasElement.attributeValue("datasource");
                     if (StringUtils.isNotBlank(aliasDatasourceId) && StringUtils.isNotBlank(originalDatasourceId)) {
                         frameLoaderInnerContext.getAliasesMap().put(aliasDatasourceId, originalDatasourceId);

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameComponentLoader.java
@@ -17,6 +17,7 @@
 package com.haulmont.cuba.gui.xml.layout.loaders;
 
 import com.haulmont.bali.datastruct.Pair;
+import com.haulmont.bali.util.Dom4j;
 import com.haulmont.cuba.core.global.AppBeans;
 import com.haulmont.cuba.gui.ComponentsHelper;
 import com.haulmont.cuba.gui.GuiDevelopmentException;
@@ -132,14 +133,12 @@ public class FrameComponentLoader extends ContainerLoader<Frame> {
         Element dsAliases = element.element("dsContext");
         if (dsAliases != null && frameLoader instanceof FrameLoader) {
             ComponentLoaderContext frameLoaderInnerContext = ((FrameLoader) frameLoader).getInnerContext();
-            for (Object o : dsAliases.elements("alias")) {
-                if (o instanceof Element) {
-                    String aliasDatasourceId = ((Element) o).attributeValue("name");
-                    String originalDatasourceId = ((Element) o).attributeValue("datasource");
+            for (Element aliasElement : Dom4j.elements(dsAliases, "alias")) {
+                    String aliasDatasourceId = aliasElement.attributeValue("name");
+                    String originalDatasourceId = aliasElement.attributeValue("datasource");
                     if (StringUtils.isNotBlank(aliasDatasourceId) && StringUtils.isNotBlank(originalDatasourceId)) {
                         frameLoaderInnerContext.getAliasesMap().put(aliasDatasourceId, originalDatasourceId);
                     }
-                }
             }
         }
     }

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FrameLoader.java
@@ -152,7 +152,7 @@ public class FrameLoader<T extends Frame> extends ContainerLoader<T> {
         Element dsContextElement = element.element("dsContext");
         DsContextLoader contextLoader = new DsContextLoader(context.getDsContext().getDataSupplier());
 
-        DsContext dsContext = contextLoader.loadDatasources(dsContextElement, context.getDsContext());
+        DsContext dsContext = contextLoader.loadDatasources(dsContextElement, context.getDsContext(), innerContext.getAliasesMap());
 
         assignXmlDescriptor(resultComponent, element);
 
@@ -304,5 +304,9 @@ public class FrameLoader<T extends Frame> extends ContainerLoader<T> {
                 FrameLoader.this.context.executePostInitTasks();
             }
         }
+    }
+
+    public ComponentLoaderContext getInnerContext() {
+        return innerContext;
     }
 }


### PR DESCRIPTION
New feature was implemented according to our needs and theese questions
https://www.cuba-platform.ru/discuss/t/psevdonimy-dlya-istochnikov-dannyh-vlozhennyh-frejmov/268
https://www.cuba-platform.ru/discuss/t/peredacha-datasource-vo-frame/666/2

Usage:
```xml
<frame id="myFrame" screen="myFrame" width="100%">
    <dsContext>
        <alias name="animalsDs" datasource="dogsDs"/>
    </dsContext>
</frame>
<frame id="myFrame2" screen="myFrame" width="100%">
    <dsContext>
        <alias name="animalsDs" datasource="catsDs"/>
    </dsContext>
</frame>
```

myFrame.xml:
```xml
<window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
        class="com.company.name.gui.MyFrame"
        messagesPack="com.company.name.gui">
    <layout>
        <table id="animalsTable">
            <columns>
                <column id="name"/>
            </columns>
            <rows datasource="animalsDs"/>
        </table>
    </layout>
</window>
```