### PR TITLE
Feature that allows you to use SpEL in @NamePattern of entity

### DIFF
--- a/modules/core/test/com/haulmont/cuba/namepattern/NamePatternTest.java
+++ b/modules/core/test/com/haulmont/cuba/namepattern/NamePatternTest.java
@@ -1,0 +1,85 @@
+package com.haulmont.cuba.namepattern;
+
+import com.haulmont.cuba.testmodel.namepattern.MethodNamePatternEntity;
+import com.haulmont.cuba.testmodel.namepattern.SpelNamePatternEntity;
+import com.haulmont.cuba.testmodel.namepattern.SimpleNamePatternEntity;
+import com.haulmont.cuba.testsupport.TestContainer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Rushan Zagidullin
+ * @since 17.07.2018
+ */
+public class NamePatternTest {
+
+    @ClassRule
+    public static TestContainer container = TestContainer.Common.INSTANCE;
+
+    SimpleNamePatternEntity simpleNamePatternEntity1;
+    SimpleNamePatternEntity simpleNamePatternEntity2;
+    MethodNamePatternEntity methodNamePatternEntity1;
+    MethodNamePatternEntity methodNamePatternEntity2;
+    SpelNamePatternEntity spelNamePatternEntity1;
+    SpelNamePatternEntity spelNamePatternEntity2;
+
+    @SuppressWarnings("IncorrectCreateEntity")
+    @Before
+    public void setUp() {
+        simpleNamePatternEntity1 = new SimpleNamePatternEntity();
+        simpleNamePatternEntity1.setName("name1");
+
+        simpleNamePatternEntity2 = new SimpleNamePatternEntity();
+        simpleNamePatternEntity2.setName(null);
+
+        methodNamePatternEntity1 = new MethodNamePatternEntity();
+        methodNamePatternEntity1.setName("name1");
+
+        methodNamePatternEntity2 = new MethodNamePatternEntity();
+        methodNamePatternEntity2.setName(null);
+
+        spelNamePatternEntity1 = new SpelNamePatternEntity();
+        spelNamePatternEntity1.setName("name1");
+        spelNamePatternEntity1.setNumber(5);
+        spelNamePatternEntity1.setNumber2(null);
+
+        spelNamePatternEntity2 = new SpelNamePatternEntity();
+        spelNamePatternEntity2.setName("name2");
+        spelNamePatternEntity2.setNumber(null);
+        spelNamePatternEntity2.setNumber2(null);
+    }
+
+    @Test
+    public void testSimpleNamePatternEntity1() {
+        assertEquals("name1", simpleNamePatternEntity1.getInstanceName());
+    }
+
+    @Test
+    public void testSimpleNamePatternEntity2() {
+        assertEquals("", simpleNamePatternEntity2.getInstanceName());
+    }
+
+    @Test
+    public void testMethodNamePatternEntity1() {
+        assertEquals("name1", methodNamePatternEntity1.getInstanceName());
+    }
+
+    @Test
+    public void testMethodNamePatternEntity2() {
+        assertNull(methodNamePatternEntity2.getInstanceName());
+    }
+
+    @Test
+    public void testComplexNamePatternEntity1() {
+        assertEquals("Hello, my name is name1. Sum of numbers = 5", spelNamePatternEntity1.getInstanceName());
+    }
+
+    @Test
+    public void testComplexNamePatternEntity2() {
+        assertEquals("Hello, my name is name2. Sum of numbers = 0", spelNamePatternEntity2.getInstanceName());
+    }
+}

--- a/modules/core/test/com/haulmont/cuba/namepattern/NamePatternTestBean.java
+++ b/modules/core/test/com/haulmont/cuba/namepattern/NamePatternTestBean.java
@@ -1,0 +1,31 @@
+package com.haulmont.cuba.namepattern;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @author Rushan Zagidullin
+ * @since 17.07.2018
+ */
+@Component("cuba_NamePatternTestBean")
+public class NamePatternTestBean {
+    public int sum(Integer... values) {
+        return Optional.ofNullable(values)
+                .map(ints -> Arrays.stream(ints)
+                        .filter(Objects::nonNull)
+                        .mapToInt(Integer::intValue)
+                        .sum())
+                .orElse(0);
+    }
+
+    public String concat(String... values) {
+        return Optional.ofNullable(values)
+                .map(strings -> Arrays.stream(strings)
+                        .collect(Collectors.joining()))
+                .orElse("");
+    }
+}

--- a/modules/core/test/com/haulmont/cuba/testmodel/namepattern/MethodNamePatternEntity.java
+++ b/modules/core/test/com/haulmont/cuba/testmodel/namepattern/MethodNamePatternEntity.java
@@ -1,0 +1,34 @@
+package com.haulmont.cuba.testmodel.namepattern;
+
+import com.haulmont.chile.core.annotations.NamePattern;
+import com.haulmont.cuba.core.entity.StandardEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * @author Rushan Zagidullin
+ * @since 17.07.2018
+ */
+@NamePattern("#formatName|name")
+@Table(name = "TEST_METHOD_NAME_PATTERN_ENTITY")
+@Entity(name = "test$MethodNamePatternEntity")
+public class MethodNamePatternEntity extends StandardEntity {
+    private static final long serialVersionUID = -833743669993760614L;
+
+    @Column(name = "NAME")
+    protected String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String formatName() {
+        return getName();
+    }
+}

--- a/modules/core/test/com/haulmont/cuba/testmodel/namepattern/SimpleNamePatternEntity.java
+++ b/modules/core/test/com/haulmont/cuba/testmodel/namepattern/SimpleNamePatternEntity.java
@@ -1,0 +1,30 @@
+package com.haulmont.cuba.testmodel.namepattern;
+
+import com.haulmont.chile.core.annotations.NamePattern;
+import com.haulmont.cuba.core.entity.StandardEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * @author Rushan Zagidullin
+ * @since 17.07.2018
+ */
+@NamePattern("%s|name")
+@Table(name = "TEST_SIMPLE_NAME_PATTERN_ENTITY")
+@Entity(name = "test$SimpleNamePatternEntity")
+public class SimpleNamePatternEntity extends StandardEntity {
+    private static final long serialVersionUID = -833743669993760614L;
+
+    @Column(name = "NAME")
+    protected String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/modules/core/test/com/haulmont/cuba/testmodel/namepattern/SpelNamePatternEntity.java
+++ b/modules/core/test/com/haulmont/cuba/testmodel/namepattern/SpelNamePatternEntity.java
@@ -1,0 +1,52 @@
+package com.haulmont.cuba.testmodel.namepattern;
+
+import com.haulmont.chile.core.annotations.NamePattern;
+import com.haulmont.cuba.core.entity.StandardEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * @author Rushan Zagidullin
+ * @since 17.07.2018
+ */
+@NamePattern("#{@cuba_NamePatternTestBean.concat('Hello, my name is ', name, '. Sum of numbers = ', @cuba_NamePatternTestBean.sum(number, number2))}|name")
+@Table(name = "TEST_SPEL_NAME_PATTERN_ENTITY")
+@Entity(name = "test$SpelNamePatternEntity")
+public class SpelNamePatternEntity extends StandardEntity {
+    private static final long serialVersionUID = -833743669993760614L;
+
+    @Column(name = "NAME")
+    protected String name;
+
+    @Column(name = "NUMBER")
+    protected Integer number;
+
+    @Column(name = "NUMBER_2")
+    protected Integer number2;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getNumber() {
+        return number;
+    }
+
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+
+    public Integer getNumber2() {
+        return number2;
+    }
+
+    public void setNumber2(Integer number2) {
+        this.number2 = number2;
+    }
+}

--- a/modules/core/test/cuba-test-persistence.xml
+++ b/modules/core/test/cuba-test-persistence.xml
@@ -91,5 +91,9 @@
         <class>com.haulmont.cuba.testmodel.jpa_cascade.JpaCascadeItem</class>
 
         <class>com.haulmont.cuba.testmodel.not_persistent.CustomerWithNonPersistentRef</class>
+
+        <class>com.haulmont.cuba.testmodel.namepattern.MethodNamePatternEntity</class>
+        <class>com.haulmont.cuba.testmodel.namepattern.SimpleNamePatternEntity</class>
+        <class>com.haulmont.cuba.testmodel.namepattern.SpelNamePatternEntity</class>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
One more convinient way to specify NamePattern. Using SpEL allows you to invoke bean methods like a charm. 

### The expression language supports the following functionality:
Literal expressions
Boolean and relational operators
Regular expressions
Class expressions
Accessing properties, arrays, lists, maps
Method invocation
Relational operators
Assignment
Calling constructors
Bean references
Array construction
Inline lists
Inline maps
Ternary operator
Variables
User defined functions
Collection projection
Collection selection
Templated expressions

More information: https://docs.spring.io/spring/docs/4.3.14.RELEASE/spring-framework-reference/html/expressions.html