### PR TITLE
Add create() and getReference() methods to DataManager

### DIFF
--- a/modules/client/src/com/haulmont/cuba/client/sys/DataManagerClientImpl.java
+++ b/modules/client/src/com/haulmont/cuba/client/sys/DataManagerClientImpl.java
@@ -19,6 +19,7 @@ package com.haulmont.cuba.client.sys;
 
 import com.haulmont.chile.core.model.MetaClass;
 import com.haulmont.cuba.core.app.DataService;
+import com.haulmont.cuba.core.entity.BaseGenericIdEntity;
 import com.haulmont.cuba.core.entity.Entity;
 import com.haulmont.cuba.core.entity.KeyValueEntity;
 import com.haulmont.cuba.core.global.*;
@@ -40,6 +41,9 @@ public class DataManagerClientImpl implements DataManager {
 
     @Inject
     protected Metadata metadata;
+
+    @Inject
+    protected EntityStates entityStates;
 
     @Nullable
     @Override
@@ -145,5 +149,18 @@ public class DataManagerClientImpl implements DataManager {
     @Override
     public DataManager secure() {
         return this;
+    }
+
+    @Override
+    public <T> T create(Class<T> entityClass) {
+        return metadata.create(entityClass);
+    }
+
+    @Override
+    public <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
+        T entity = metadata.create(entityClass);
+        entity.setId(id);
+        entityStates.makePatch(entity);
+        return entity;
     }
 }

--- a/modules/core/src/com/haulmont/cuba/core/app/DataManagerBean.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/DataManagerBean.java
@@ -44,6 +44,9 @@ public class DataManagerBean implements DataManager {
     protected MetadataTools metadataTools;
 
     @Inject
+    protected EntityStates entityStates;
+
+    @Inject
     protected ServerConfig serverConfig;
 
     @Inject
@@ -268,6 +271,19 @@ public class DataManagerBean implements DataManager {
     @Override
     public <T> FluentValueLoader<T> loadValue(String queryString, Class<T> valueClass) {
         return new FluentValueLoader<>(queryString, valueClass, this);
+    }
+
+    @Override
+    public <T> T create(Class<T> entityClass) {
+        return metadata.create(entityClass);
+    }
+
+    @Override
+    public <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
+        T entity = metadata.create(entityClass);
+        entity.setId(id);
+        entityStates.makePatch(entity);
+        return entity;
     }
 
     protected boolean writeCrossDataStoreReferences(Entity entity, Collection<Entity> allEntities) {

--- a/modules/core/test/com/haulmont/cuba/core/DataManagerTransactionalUsageTest.java
+++ b/modules/core/test/com/haulmont/cuba/core/DataManagerTransactionalUsageTest.java
@@ -48,9 +48,6 @@ public class DataManagerTransactionalUsageTest {
         @Inject
         private TransactionalDataManager txDataManager;
 
-        @Inject
-        private Metadata metadata;
-
         @Transactional
         public Id<OrderLine, UUID> sell(String productName, Integer quantity) {
             Product product = txDataManager.load(Product.class)
@@ -58,13 +55,13 @@ public class DataManagerTransactionalUsageTest {
                     .parameter("name", productName)
                     .optional()
                     .orElseGet(() -> {
-                        Product p = metadata.create(Product.class);
+                        Product p = txDataManager.create(Product.class);
                         p.setName(productName);
                         p.setQuantity(100); // initial quantity of a new product
                         return txDataManager.save(p);
                     });
 
-            OrderLine orderLine = metadata.create(OrderLine.class);
+            OrderLine orderLine = txDataManager.create(OrderLine.class);
             orderLine.setProduct(product);
             orderLine.setQuantity(quantity);
             txDataManager.save(orderLine);
@@ -80,13 +77,13 @@ public class DataManagerTransactionalUsageTest {
                         .parameter("name", productName)
                         .optional()
                         .orElseGet(() -> {
-                            Product p = metadata.create(Product.class);
+                            Product p = txDataManager.create(Product.class);
                             p.setName(productName);
                             p.setQuantity(100); // initial quantity of a new product
                             return secureDm.save(p);
                         });
 
-                OrderLine orderLine = metadata.create(OrderLine.class);
+                OrderLine orderLine = txDataManager.create(OrderLine.class);
                 orderLine.setProduct(product);
                 orderLine.setQuantity(quantity);
                 secureDm.save(orderLine);
@@ -154,13 +151,11 @@ public class DataManagerTransactionalUsageTest {
     public static TestContainer cont = TestContainer.Common.INSTANCE;
 
     protected DataManager dataManager;
-    private Metadata metadata;
     private Persistence persistence;
 
     @Before
     public void setUp() throws Exception {
         dataManager = AppBeans.get(DataManager.class);
-        metadata = cont.metadata();
         persistence = cont.persistence();
 
         QueryRunner runner = new QueryRunner(persistence.getDataSource());
@@ -181,7 +176,7 @@ public class DataManagerTransactionalUsageTest {
 
         // change Product in OrderLIne
 
-        Product product2 = metadata.create(Product.class);
+        Product product2 = dataManager.create(Product.class);
         product2.setName("def");
         product2.setQuantity(100);
         dataManager.commit(product2);
@@ -216,7 +211,7 @@ public class DataManagerTransactionalUsageTest {
                 .one();
         assertEquals(90, (int) product1.getQuantity());
 
-        Product product2 = metadata.create(Product.class);
+        Product product2 = dataManager.create(Product.class);
         product2.setName("def");
         product2.setQuantity(100);
         dataManager.commit(product2);

--- a/modules/core/test/spec/cuba/core/data_manager/DataManagerCommitTest.groovy
+++ b/modules/core/test/spec/cuba/core/data_manager/DataManagerCommitTest.groovy
@@ -72,8 +72,7 @@ class DataManagerCommitTest extends Specification {
 
         when:
 
-        entityStates.makePatch(customer)
-        order1.customer = customer
+        order1.customer = dataManager.getReference(Customer, customer.id)
         Order order2 = dataManager.commit(order1)
 
         then:
@@ -94,10 +93,7 @@ class DataManagerCommitTest extends Specification {
 
         when:
 
-        Customer customer1 = new Customer(id: customer.id)
-        entityStates.makePatch(customer1)
-
-        dataManager.remove(customer1)
+        dataManager.remove(dataManager.getReference(Customer, customer.id))
 
         Customer customer2 = dataManager.load(Customer).id(customer.id).softDeletion(false).one()
 

--- a/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
@@ -248,12 +248,10 @@ public interface DataManager {
     }
 
     /**
-     * Creates a new entity instance. This is a shortcut to {@code Metadata.create()}.
+     * Creates a new entity instance in memory. This is a shortcut to {@code Metadata.create()}.
      * @param entityClass   entity class
      */
-    default <T> T create(Class<T> entityClass) {
-        return AppBeans.get(Metadata.class).create(entityClass);
-    }
+    <T> T create(Class<T> entityClass);
 
     /**
      * Returns an entity instance which can be used as a reference to an object which exists in the database.
@@ -264,7 +262,6 @@ public interface DataManager {
      * user.setGroup(dataManager.getReference(Group.class, groupId));
      * dataManager.commit(user);
      * </pre>
-     *
      * A reference can also be used to delete an existing object by id:
      * <pre>
      * dataManager.remove(dataManager.getReference(Customer.class, customerId));
@@ -273,10 +270,5 @@ public interface DataManager {
      * @param entityClass   entity class
      * @param id            id of an existing object
      */
-    default <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
-        T entity = AppBeans.get(Metadata.class).create(entityClass);
-        entity.setId(id);
-        AppBeans.get(EntityStates.class).makePatch(entity);
-        return entity;
-    }
+    <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id);
 }

--- a/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/DataManager.java
@@ -18,6 +18,7 @@
 package com.haulmont.cuba.core.global;
 
 import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.BaseGenericIdEntity;
 import com.haulmont.cuba.core.entity.Entity;
 import com.haulmont.cuba.core.entity.KeyValueEntity;
 import com.haulmont.cuba.core.entity.contracts.Id;
@@ -244,5 +245,38 @@ public interface DataManager {
      */
     default <T> FluentValueLoader<T> loadValue(String queryString, Class<T> valueClass) {
         return new FluentValueLoader<>(queryString, valueClass, this);
+    }
+
+    /**
+     * Creates a new entity instance. This is a shortcut to {@code Metadata.create()}.
+     * @param entityClass   entity class
+     */
+    default <T> T create(Class<T> entityClass) {
+        return AppBeans.get(Metadata.class).create(entityClass);
+    }
+
+    /**
+     * Returns an entity instance which can be used as a reference to an object which exists in the database.
+     * <p>
+     * For example, if you are creating a User, you have to set a Group the user belongs to. If you know the group id,
+     * you could load it from the database and set to the user. This method saves you from unneeded database round trip:
+     * <pre>
+     * user.setGroup(dataManager.getReference(Group.class, groupId));
+     * dataManager.commit(user);
+     * </pre>
+     *
+     * A reference can also be used to delete an existing object by id:
+     * <pre>
+     * dataManager.remove(dataManager.getReference(Customer.class, customerId));
+     * </pre>
+     *
+     * @param entityClass   entity class
+     * @param id            id of an existing object
+     */
+    default <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
+        T entity = AppBeans.get(Metadata.class).create(entityClass);
+        entity.setId(id);
+        AppBeans.get(EntityStates.class).makePatch(entity);
+        return entity;
     }
 }

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/GenericDataSupplier.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/GenericDataSupplier.java
@@ -17,6 +17,7 @@
 package com.haulmont.cuba.gui.data.impl;
 
 import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.BaseGenericIdEntity;
 import com.haulmont.cuba.core.entity.Entity;
 import com.haulmont.cuba.core.entity.KeyValueEntity;
 import com.haulmont.cuba.core.global.*;
@@ -87,6 +88,16 @@ public class GenericDataSupplier implements DataSupplier {
     @Override
     public DataManager secure() {
         return getDataManager();
+    }
+
+    @Override
+    public <T> T create(Class<T> entityClass) {
+        return getDataManager().create(entityClass);
+    }
+
+    @Override
+    public <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
+        return getDataManager().getReference(entityClass, id);
     }
 
     @Override

--- a/modules/gui/test/com/haulmont/cuba/gui/data/impl/TestDataSupplier.java
+++ b/modules/gui/test/com/haulmont/cuba/gui/data/impl/TestDataSupplier.java
@@ -18,6 +18,7 @@
 package com.haulmont.cuba.gui.data.impl;
 
 import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.BaseGenericIdEntity;
 import com.haulmont.cuba.core.entity.Entity;
 import com.haulmont.cuba.core.entity.KeyValueEntity;
 import com.haulmont.cuba.core.global.*;
@@ -127,5 +128,15 @@ public class TestDataSupplier implements DataSupplier {
     @Override
     public DataManager secure() {
         return this;
+    }
+
+    @Override
+    public <T> T create(Class<T> entityClass) {
+        return null;
+    }
+
+    @Override
+    public <T extends BaseGenericIdEntity<K>, K> T getReference(Class<T> entityClass, K id) {
+        return null;
     }
 }


### PR DESCRIPTION
These are just convenient shortcuts to avoid using Metadata and EntityStates.