### PR TITLE
Entity is not reloaded if it is loaded with view which includes dataSource view

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/components/EditorWindowDelegate.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/EditorWindowDelegate.java
@@ -151,7 +151,7 @@ public class EditorWindowDelegate extends WindowDelegate {
             }
             item = EntityCopyUtils.copyCompositions(item);
             handlePreviouslyDeletedCompositionItems(item, parentDs);
-        } else if (!PersistenceHelper.isNew(item)) {
+        } else if (!PersistenceHelper.isNew(item) && !entityStates.isLoadedWithView(item, ds.getView())) {
             item = dataservice.reload(item, ds.getView(), ds.getMetaClass(), ds.getLoadDynamicAttributes());
         }
 


### PR DESCRIPTION
CUBA.platform does not reload entity if it is loaded with correct view. When CUBA.platform opens an edit screen, the platform reloads an entity (if an entity is not new). The pull request resolves the problem.