### PR TITLE
Copy security state on composition copy

### DIFF
--- a/modules/global/src/com/haulmont/cuba/core/entity/BaseEntityInternalAccess.java
+++ b/modules/global/src/com/haulmont/cuba/core/entity/BaseEntityInternalAccess.java
@@ -175,6 +175,10 @@ public final class BaseEntityInternalAccess {
         }
     }
 
+    public static boolean isEntitySupportSecurityState(Entity entity) {
+        return entity instanceof BaseGenericIdEntity || entity instanceof EmbeddableEntity;
+    }
+
     public static SecurityState getSecurityState(Entity entity) {
         Preconditions.checkNotNullArgument(entity, "Entity is null");
         SecurityState securityState;

--- a/modules/global/src/com/haulmont/cuba/core/entity/BaseEntityInternalAccess.java
+++ b/modules/global/src/com/haulmont/cuba/core/entity/BaseEntityInternalAccess.java
@@ -175,7 +175,7 @@ public final class BaseEntityInternalAccess {
         }
     }
 
-    public static boolean isEntitySupportSecurityState(Entity entity) {
+    public static boolean supportsSecurityState(Entity entity) {
         return entity instanceof BaseGenericIdEntity || entity instanceof EmbeddableEntity;
     }
 

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/EntityCopyUtils.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/EntityCopyUtils.java
@@ -44,6 +44,10 @@ public class EntityCopyUtils {
         }
         copyCompositions(source, dest);
 
+        if (BaseEntityInternalAccess.isEntitySupportSecurityState(source)) {
+            BaseEntityInternalAccess.setSecurityState(dest, BaseEntityInternalAccess.getSecurityState(source));
+        }
+
         return dest;
     }
 

--- a/modules/gui/src/com/haulmont/cuba/gui/data/impl/EntityCopyUtils.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/data/impl/EntityCopyUtils.java
@@ -44,7 +44,7 @@ public class EntityCopyUtils {
         }
         copyCompositions(source, dest);
 
-        if (BaseEntityInternalAccess.isEntitySupportSecurityState(source)) {
+        if (BaseEntityInternalAccess.supportsSecurityState(source)) {
             BaseEntityInternalAccess.setSecurityState(dest, BaseEntityInternalAccess.getSecurityState(source));
         }
 


### PR DESCRIPTION
State does not copy on composition copy to the new entity.

How to reproduce: open editor of entity with loaded security state with parentDs; `__securityState` of entity in editor will be null