### PR TITLE
Refactoring EntityLogDynamicAttributesTest - Test case split up

### DIFF
--- a/modules/core/test/spec/cuba/core/entity_log/EntityLogDynamicAttributesTest.groovy
+++ b/modules/core/test/spec/cuba/core/entity_log/EntityLogDynamicAttributesTest.groovy
@@ -18,7 +18,6 @@ package spec.cuba.core.entity_log
 
 import com.haulmont.bali.db.QueryRunner
 import com.haulmont.cuba.core.EntityManager
-import com.haulmont.cuba.core.Query
 import com.haulmont.cuba.core.Transaction
 import com.haulmont.cuba.core.TypedQuery
 import com.haulmont.cuba.core.app.dynamicattributes.DynamicAttributesManagerAPI
@@ -30,6 +29,7 @@ import com.haulmont.cuba.core.global.AppBeans
 import com.haulmont.cuba.core.global.DataManager
 import com.haulmont.cuba.core.global.LoadContext
 import com.haulmont.cuba.core.global.View
+import com.haulmont.cuba.security.app.EntityLog
 import com.haulmont.cuba.security.app.EntityLogAPI
 import com.haulmont.cuba.security.entity.*
 import com.haulmont.cuba.testsupport.TestContainer
@@ -45,66 +45,62 @@ class EntityLogDynamicAttributesTest extends Specification {
     @Shared @ClassRule
     public TestContainer cont = TestContainer.Common.INSTANCE
 
-    private UUID user1Id, categoryId, categoryAttributeId
-    private def entityLog
+    private UUID userId, categoryId, categoryAttributeId
+    private EntityLog entityLog
     private DataManager dataManager
-    private def dynamicAttributesManagerAPI
+    private DynamicAttributesManagerAPI dynamicAttributesManagerAPI
+
+    private final String DYNAMIC_ATTRIBUTE_NAME = '+userAttribute'
 
 
     void setup() {
         _cleanup()
 
         cont.persistence().runInTransaction { em ->
-            Query q
-            q = em.createNativeQuery("delete from SEC_ENTITY_LOG")
-            q.executeUpdate()
+            clearTable(em, "SEC_ENTITY_LOG")
+            clearTable(em, "SYS_ATTR_VALUE")
 
-            q = em.createNativeQuery("delete from SYS_ATTR_VALUE")
-            q.executeUpdate()
-
-            LoggedEntity le = new LoggedEntity()
-            le.setName('sec$User')
-            le.setAuto(true)
+            LoggedEntity le = new LoggedEntity(name: 'sec$User', auto: true)
             em.persist(le)
 
-            LoggedAttribute la = new LoggedAttribute()
-            la.setEntity(le)
-            la.setName('name')
-            em.persist(la)
+            createLoggedAttributeWithName(em, le, 'name')
+            createLoggedAttributeWithName(em, le, DYNAMIC_ATTRIBUTE_NAME)
 
-            la = new LoggedAttribute()
-            la.setEntity(le)
-            la.setName('+userAttribute')
-            em.persist(la)
-
-            Category category = new Category()
-            category.setName("user")
-            category.setEntityType("sec\$User")
-            categoryId = category.getId()
+            Category category = new Category(name: 'user', entityType: 'sec$User')
+            categoryId = category.id
             em.persist(category)
 
-            CategoryAttribute categoryAttribute = new CategoryAttribute()
-            categoryAttribute.setName("userAttribute")
-            categoryAttribute.setCode("userAttribute")
-            categoryAttribute.setCategory(category)
-            categoryAttribute.setCategoryEntityType("sec\$User")
-            categoryAttribute.setDataType(PropertyType.STRING)
-            categoryAttribute.setDefaultEntity(new ReferenceToEntity())
-            categoryAttributeId = categoryAttribute.getId()
+            CategoryAttribute categoryAttribute = new CategoryAttribute(
+                    name: "userAttribute",
+                    code: "userAttribute",
+                    category: category,
+                    categoryEntityType: 'sec$User',
+                    dataType: PropertyType.STRING,
+                    defaultEntity: new ReferenceToEntity()   
+            )
+            categoryAttributeId = categoryAttribute.id
             em.persist(categoryAttribute)
 
         }
-        entityLog = AppBeans.get(EntityLogAPI.class)
+        entityLog = AppBeans.get(EntityLogAPI.class) as EntityLog
         entityLog.invalidateCache()
         dynamicAttributesManagerAPI = AppBeans.get(DynamicAttributesManagerAPI.class)
         dynamicAttributesManagerAPI.loadCache()
         dataManager = AppBeans.get(DataManager.class)
     }
 
+    protected void createLoggedAttributeWithName(EntityManager em, LoggedEntity le, String name) {
+        em.persist(new LoggedAttribute(entity: le, name: name))
+    }
+
+    protected void clearTable(EntityManager em, String table) {
+        em.createNativeQuery("delete from " + table).executeUpdate()
+    }
+
     void cleanup() {
         _cleanup()
-        if (user1Id != null)
-            cont.deleteRecord("SEC_USER", user1Id)
+        if (userId != null)
+            cont.deleteRecord("SEC_USER", userId)
 
         cont.deleteRecord("SYS_CATEGORY_ATTR", categoryAttributeId)
         cont.deleteRecord("SYS_CATEGORY", categoryId)
@@ -118,9 +114,8 @@ class EntityLogDynamicAttributesTest extends Specification {
     }
 
     private List<EntityLogItem> getEntityLogItems(def userId) {
-        Transaction tx
+        Transaction tx = cont.persistence().createTransaction()
         List<EntityLogItem> items
-        tx = cont.persistence().createTransaction()
         try {
             EntityManager em = cont.persistence().getEntityManager()
             TypedQuery<EntityLogItem> query = em.createQuery(
@@ -133,74 +128,115 @@ class EntityLogDynamicAttributesTest extends Specification {
         } finally {
             tx.end()
         }
-        return items
+
+        items
     }
 
     def "Entity Log: create/update/delete entity with dynamic attribute"() {
-        Group group = cont.persistence().callInTransaction({ em ->
+
+        given:
+
+        Group group = findCompanyGroup()
+
+        and:
+
+        def expectedRegularAttributeValue = 'test-name'
+        def expectedDynamicAttributeValue = "userName"
+
+        and:
+
+        User user = cont.metadata().create(User)
+        userId = user.getId()
+        user.group = group
+        user.login = "test"
+        user.name = expectedRegularAttributeValue
+
+        and: 'dynamic attribute needs to be loaded explicitly in order to set it'
+
+        user.getValue(DYNAMIC_ATTRIBUTE_NAME)
+
+        and:
+
+        user.setValue(DYNAMIC_ATTRIBUTE_NAME, expectedDynamicAttributeValue)
+
+        when:
+
+        dataManager.commit(user)
+
+        then:
+
+        def entityLogItemsAfterCreate = getEntityLogItems(userId)
+        entityLogItemsAfterCreate.size() == 1
+
+        and:
+
+        def createdEntityLogItem = entityLogItemsAfterCreate[0]
+
+        createdEntityLogItem.type == EntityLogItem.Type.CREATE
+        createdEntityLogItem.attributes.find { it.name == 'name' }.value == expectedRegularAttributeValue
+
+        and:
+
+        entityLogAttributeForDynamicAttribute(createdEntityLogItem).value == expectedDynamicAttributeValue
+
+        when:
+
+        user = reloadUserFromDbWithDynamicAttributes(user)
+        userId = user.id
+        def updatedDynamicAttributeValue = "userName1"
+        user.setValue(DYNAMIC_ATTRIBUTE_NAME, updatedDynamicAttributeValue)
+
+        dataManager.commit(user)
+
+        then:
+
+        def entityLogItemsAfterModify = getEntityLogItems(userId)
+        entityLogItemsAfterModify.size() == 2
+        def modifiedEntityLogItem = entityLogItemsAfterModify[0]
+
+        modifiedEntityLogItem.type == EntityLogItem.Type.MODIFY
+
+        and:
+
+        entityLogAttributeForDynamicAttribute(modifiedEntityLogItem).oldValue == expectedDynamicAttributeValue
+        entityLogAttributeForDynamicAttribute(modifiedEntityLogItem).value == updatedDynamicAttributeValue
+
+        when:
+
+        user = reloadUserFromDbWithDynamicAttributes(user)
+        userId = user.id
+        user.setValue(DYNAMIC_ATTRIBUTE_NAME, null)
+
+        dataManager.commit(user)
+
+        then:
+
+        def entityLogItemsAfterDelete = getEntityLogItems(userId)
+        entityLogItemsAfterDelete.size() == 3
+        def deletedEntityLogItem = entityLogItemsAfterDelete[0]
+
+        deletedEntityLogItem.type == EntityLogItem.Type.MODIFY
+
+        entityLogAttributeForDynamicAttribute(deletedEntityLogItem).value == ""
+        entityLogAttributeForDynamicAttribute(deletedEntityLogItem).oldValue == updatedDynamicAttributeValue
+    }
+
+    protected EntityLogAttr entityLogAttributeForDynamicAttribute(EntityLogItem entityLogItem) {
+        entityLogItem.attributes.find { it.name == DYNAMIC_ATTRIBUTE_NAME }
+    }
+
+    protected Group findCompanyGroup() {
+        cont.persistence().callInTransaction { em ->
             em.find(Group.class, TestSupport.COMPANY_GROUP_ID)
-        })
+        }
+    }
 
-        when:
 
-        User user1 = cont.metadata().create(User)
-        user1Id = user1.getId()
-        user1.setGroup(group)
-        user1.setLogin("test")
-        user1.setName("test-name")
-        user1.getValue("+userAttribute")
-        user1.setValue("+userAttribute", "userName")
-
-        dataManager.commit(user1)
-
-        then:
-
-        def items = getEntityLogItems(user1Id)
-        items.size() == 1
-        def item = items[0]
-
-        item.type == EntityLogItem.Type.CREATE
-        item.attributes.find({ it.name == 'name' }).value == 'test-name'
-        item.attributes.find({ it.name == '+userAttribute' }).value == 'userName'
-
-        when:
-
-        LoadContext<User> loadContext = new LoadContext(User.class)
-                .setId(user1).setView(View.LOCAL).setLoadDynamicAttributes(true)
-        user1 = dataManager.load(loadContext)
-        user1Id = user1.getId()
-        user1.setValue("+userAttribute", "userName1")
-
-        dataManager.commit(user1)
-
-        then:
-
-        def items1 = getEntityLogItems(user1Id)
-        items1.size() == 2
-        def item1 = items1[0]
-
-        item1.type == EntityLogItem.Type.MODIFY
-        item1.attributes.find({ it.name == '+userAttribute' }).oldValue == 'userName'
-        item1.attributes.find({ it.name == '+userAttribute' }).value == 'userName1'
-
-        when:
-
-        loadContext = new LoadContext(User.class)
-                .setId(user1).setView(View.LOCAL).setLoadDynamicAttributes(true)
-        user1 = (User) dataManager.load(loadContext)
-        user1Id = user1.getId()
-        user1.setValue("+userAttribute", null)
-
-        dataManager.commit(user1)
-
-        then:
-
-        def items2 = getEntityLogItems(user1Id)
-        items2.size() == 3
-        def item2 = items2[0]
-
-        item2.type == EntityLogItem.Type.MODIFY
-        item2.attributes.find({ it.name == '+userAttribute' }).value == ""
-        item2.attributes.find({ it.name == '+userAttribute' }).oldValue == 'userName1'
+    protected User reloadUserFromDbWithDynamicAttributes(User user) {
+        LoadContext loadContext = new LoadContext(User.class)
+                .setId(user)
+                .setView(View.LOCAL)
+                .setLoadDynamicAttributes(true)
+        dataManager.load(loadContext)
     }
 }


### PR DESCRIPTION

### Test case split up of EntityLogDynamicAttributesTest

As part of my participation in [Hacktoberfest](https://hacktoberfest.digitalocean.com) I took the time to take a look at a particular Integration Test that is part of the CUBA test suite: [EntityLogDynamicAttributesTest.groovy](https://github.com/cuba-platform/cuba/blob/master/modules/core/test/spec/cuba/core/entity_log/EntityLogDynamicAttributesTest.groovy) and tried to enhance it with the following aspects:

* splitted the one existing test case into three different test cases
* renamed variables to better reflect their usage
* created helper methods to better identify what the test is doing

The split moves the original test case: _Entity Log: create/update/delete entity with dynamic attribute_ to the three different cases:

* EntityLog logs the creation of a dynamic attribute
* EntityLog logs the update of a dynamic attribute
* EntityLog logs the deletion of a dynamic attribute

The result is a test case that better expresses its original intend and carves out what is actually tested:

```
    def "EntityLog logs the creation of a dynamic attribute"() {

        given:
        User user = createUser()

        when:
        saveUserWithDynamicAttributeValue(user, 'userName')
        def log = latestEntityLogItem(user)

        then:
        isCreateType(log)

        and:
        loggedValueMatches(log, 'userName')
    }
```

I would be interested if you also find the test case description more easy to read and if it is ok for you having a lot of helper methods that support that effort.