### PR TITLE
Clarify test case intents in DataManagerCommitTest

### DIFF
--- a/modules/core/test/spec/cuba/core/data_manager/DataManagerCommitTest.groovy
+++ b/modules/core/test/spec/cuba/core/data_manager/DataManagerCommitTest.groovy
@@ -49,7 +49,7 @@ class DataManagerCommitTest extends Specification {
         entityStates = AppBeans.get(EntityStates)
     }
 
-    def "commited, returned entities allow to get entity by its ID"() {
+    def "committed, returned entities allow you to get entity by its ID"() {
 
         given:
         Order order = new Order(number: '111', customer: customer)
@@ -67,7 +67,7 @@ class DataManagerCommitTest extends Specification {
         cont.deleteRecord(order, customer)
     }
 
-    def "commited, returned entities allow to get commited entity by reference"() {
+    def "committed, returned entities allow you to get commited entity by reference"() {
 
         given:
         Order order = new Order(number: '111', customer: customer)


### PR DESCRIPTION
### Clarify test case intents in DataManagerCommitTest

As part of my participation in [Hacktoberfest](https://hacktoberfest.digitalocean.com) I took the time to take a look at a particular Integration Test that is part of the CUBA test suite: [DataManagerCommitTest.groovy](https://github.com/cuba-platform/cuba/blob/master/modules/core/test/spec/cuba/core/data_manager/DataManagerCommitTest.groovy) and tried to enhance it with the following aspects:

* clarifying the intent of the existing test cases
* applied given/when/then syntax more consistently
