### PR TITLE
Merging entity referenced to new entity that is instance of subclass of original attribute class

### DIFF
--- a/modules/core/src/com/haulmont/cuba/core/sys/EntityManagerImpl.java
+++ b/modules/core/src/com/haulmont/cuba/core/sys/EntityManagerImpl.java
@@ -361,7 +361,7 @@ public class EntityManagerImpl implements EntityManager {
                     if (!equal) {
                         dstCollection.clear();
                         for (Entity srcRef : srcCollection) {
-                            Entity reloadedRef = findOrCreate(refClass, srcRef.getId());
+                            Entity reloadedRef = findOrCreate(srcRef.getClass(), srcRef.getId());
                             dstCollection.add(reloadedRef);
                             deepCopyIgnoringNulls(srcRef, reloadedRef, visited);
                         }
@@ -372,7 +372,7 @@ public class EntityManagerImpl implements EntityManager {
                     if (srcRef.equals(destRef)) {
                         deepCopyIgnoringNulls(srcRef, destRef, visited);
                     } else {
-                        Entity reloadedRef = findOrCreate(refClass, srcRef.getId());
+                        Entity reloadedRef = findOrCreate(srcRef.getClass(), srcRef.getId());
                         dest.setValue(name, reloadedRef);
                         deepCopyIgnoringNulls(srcRef, reloadedRef, visited);
                     }

--- a/modules/core/test/com/haulmont/cuba/core/sys/EntityManagerTest.java
+++ b/modules/core/test/com/haulmont/cuba/core/sys/EntityManagerTest.java
@@ -20,7 +20,9 @@ package com.haulmont.cuba.core.sys;
 import com.haulmont.cuba.core.EntityManager;
 import com.haulmont.cuba.core.Transaction;
 import com.haulmont.cuba.core.TypedQuery;
+import com.haulmont.cuba.core.entity.AppFolder;
 import com.haulmont.cuba.core.entity.EntitySnapshot;
+import com.haulmont.cuba.core.entity.Folder;
 import com.haulmont.cuba.core.global.PersistenceHelper;
 import com.haulmont.cuba.core.global.View;
 import com.haulmont.cuba.security.entity.Group;
@@ -165,6 +167,23 @@ public class EntityManagerTest {
         } finally {
             tx.end();
             cont.deleteRecord("SEC_USER", newUserId);
+        }
+    }
+
+    @Test
+    public void testMergeWithRefToNewSubclassedEntityOfOriginalAttributeClass() {
+        Transaction tx = cont.persistence().createTransaction();
+        try {
+            EntityManager em = cont.persistence().getEntityManager();
+            Folder folder = cont.metadata().create(Folder.class);
+            AppFolder appFolder = cont.metadata().create(AppFolder.class);
+            //folder can have any other folders as a parent, let's set appFolder as a parent
+            folder.setParent(appFolder);
+            em.merge(folder);
+            assertTrue(folder.getParent() instanceof AppFolder);
+            tx.commit();
+        } finally {
+            tx.end();
         }
     }
 


### PR DESCRIPTION
the method "EntityManagerImpl.deepCopyIgnoringNulls" during copying did not take into account a specific class of value, but took class of an attribute

Written new integration test that fails before hotfix, and passes after hotfix.
