### PR TITLE
Add ability to specify CC and BCC email addresses to EmailInfo #478

### DIFF
--- a/modules/core/db/init/hsql/create-db.sql
+++ b/modules/core/db/init/hsql/create-db.sql
@@ -609,6 +609,8 @@ create table SYS_SENDING_MESSAGE (
     DELETED_BY varchar(50),
     --
     ADDRESS_TO longvarchar,
+    ADDRESS_CC longvarchar,
+    ADDRESS_BCC longvarchar,
     ADDRESS_FROM varchar(100),
     CAPTION varchar(500),
     EMAIL_HEADERS varchar(500),

--- a/modules/core/db/init/mssql/create-db.sql
+++ b/modules/core/db/init/mssql/create-db.sql
@@ -635,6 +635,8 @@ create table SYS_SENDING_MESSAGE (
     DELETED_BY varchar(50),
     --
     ADDRESS_TO varchar(max),
+    ADDRESS_CC varchar(max),
+    ADDRESS_BCC varchar(max),
     ADDRESS_FROM varchar(100),
     CAPTION varchar(500),
     EMAIL_HEADERS varchar(500),

--- a/modules/core/db/init/mysql/create-db.sql
+++ b/modules/core/db/init/mysql/create-db.sql
@@ -649,6 +649,8 @@ create table SYS_SENDING_MESSAGE (
     DELETED_BY varchar(50),
     --
     ADDRESS_TO text,
+    ADDRESS_CC text,
+    ADDRESS_BCC text,
     ADDRESS_FROM varchar(100),
     CAPTION varchar(500),
     EMAIL_HEADERS varchar(500),

--- a/modules/core/db/init/oracle/create-db.sql
+++ b/modules/core/db/init/oracle/create-db.sql
@@ -338,6 +338,8 @@ create table SYS_SENDING_MESSAGE (
     DELETE_TS timestamp,
     DELETED_BY varchar2(50),
     ADDRESS_TO clob,
+    ADDRESS_CC clob,
+    ADDRESS_BCC clob,
     ADDRESS_FROM varchar2(100),
     CAPTION varchar2(500),
     EMAIL_HEADERS varchar2(500),

--- a/modules/core/db/init/postgres/create-db.sql
+++ b/modules/core/db/init/postgres/create-db.sql
@@ -615,6 +615,8 @@ create table SYS_SENDING_MESSAGE (
     DELETED_BY varchar(50),
     --
     ADDRESS_TO text,
+    ADDRESS_CC text,
+    ADDRESS_BCC text,
     ADDRESS_FROM varchar(100),
     CAPTION varchar(500),
     EMAIL_HEADERS varchar(500),

--- a/modules/core/db/update/hsql/18/181024-addCcAndBccToSendingMessage.sql
+++ b/modules/core/db/update/hsql/18/181024-addCcAndBccToSendingMessage.sql
@@ -1,0 +1,2 @@
+alter table SYS_SENDING_MESSAGE add ADDRESS_CC longvarchar;
+alter table SYS_SENDING_MESSAGE add ADDRESS_BCC longvarchar;

--- a/modules/core/db/update/mssql/18/181024-addCcAndBccToSendingMessage.sql
+++ b/modules/core/db/update/mssql/18/181024-addCcAndBccToSendingMessage.sql
@@ -1,0 +1,2 @@
+alter table SYS_SENDING_MESSAGE add ADDRESS_CC varchar(max);
+alter table SYS_SENDING_MESSAGE add ADDRESS_BCC varchar(max);

--- a/modules/core/db/update/mysql/18/181024-addCcAndBccToSendingMessage.sql
+++ b/modules/core/db/update/mysql/18/181024-addCcAndBccToSendingMessage.sql
@@ -1,0 +1,2 @@
+alter table SYS_SENDING_MESSAGE add ADDRESS_CC text;
+alter table SYS_SENDING_MESSAGE add ADDRESS_BCC text;

--- a/modules/core/db/update/oracle/18/181024-addCcAndBccToSendingMessage.sql
+++ b/modules/core/db/update/oracle/18/181024-addCcAndBccToSendingMessage.sql
@@ -1,0 +1,2 @@
+alter table SYS_SENDING_MESSAGE add ADDRESS_CC clob;
+alter table SYS_SENDING_MESSAGE add ADDRESS_BCC clob;

--- a/modules/core/db/update/postgres/18/181024-addCcAndBccToSendingMessage.sql
+++ b/modules/core/db/update/postgres/18/181024-addCcAndBccToSendingMessage.sql
@@ -1,0 +1,2 @@
+alter table SYS_SENDING_MESSAGE add ADDRESS_CC text;
+alter table SYS_SENDING_MESSAGE add ADDRESS_BCC text;

--- a/modules/core/src/com/haulmont/cuba/core/app/EmailSender.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/EmailSender.java
@@ -17,6 +17,8 @@
 
 package com.haulmont.cuba.core.app;
 
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
 import com.haulmont.cuba.core.entity.SendingAttachment;
 import com.haulmont.cuba.core.entity.SendingMessage;
 import com.haulmont.cuba.core.global.EmailHeader;
@@ -113,13 +115,14 @@ public class EmailSender implements EmailSenderAPI {
 
     protected void assignRecipient(Message.RecipientType type, String addresses, MimeMessage message) throws MessagingException {
         if (StringUtils.isNotBlank(addresses)) {
-            String[] splitAddresses = addresses.split("[,;]");
-            for (String address : splitAddresses) {
-                if (StringUtils.isNotBlank(address)) {
-                    message.addRecipient(type, new InternetAddress(address.trim()));
-                }
+            for (String address : splitAddresses(addresses)) {
+                message.addRecipient(type, new InternetAddress(address.trim()));
             }
         }
+    }
+
+    protected Iterable<String> splitAddresses(String addresses) {
+        return Splitter.on(CharMatcher.anyOf(";,")).omitEmptyStrings().trimResults().split(addresses);
     }
 
     protected void assignFromAddress(SendingMessage sendingMessage, MimeMessage msg) throws MessagingException {

--- a/modules/core/src/com/haulmont/cuba/core/app/Emailer.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/Emailer.java
@@ -170,7 +170,7 @@ public class Emailer implements EmailerAPI {
             for (String address : splitAddresses) {
                 address = address.trim();
                 if (StringUtils.isNotBlank(address)) {
-                    SendingMessage sendingMessage = convertToSendingMessage(info.getAddresses(), info.getFrom(), null,
+                    SendingMessage sendingMessage = convertToSendingMessage(address, info.getFrom(), null,
                             null, info.getCaption(), info.getBody(), info.getBodyContentType(), info.getHeaders(),
                             info.getAttachments(), attemptsCount, deadline);
 

--- a/modules/core/src/com/haulmont/cuba/core/app/Emailer.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/Emailer.java
@@ -157,15 +157,25 @@ public class Emailer implements EmailerAPI {
 
     protected List<SendingMessage> splitEmail(EmailInfo info, @Nullable Integer attemptsCount, @Nullable Date deadline) {
         List<SendingMessage> sendingMessageList = new ArrayList<>();
-        String[] splitAddresses = info.getAddresses().split("[,;]");
-        for (String address : splitAddresses) {
-            address = address.trim();
-            if (StringUtils.isNotBlank(address)) {
-                SendingMessage sendingMessage = convertToSendingMessage(address, info.getFrom(), info.getCaption(),
-                        info.getBody(), info.getBodyContentType(), info.getHeaders(), info.getAttachments(), attemptsCount,
-                        deadline);
+        if (info.isSendInOneMessage()) {
+            if (StringUtils.isNotBlank(info.getAddresses())) {
+                SendingMessage sendingMessage = convertToSendingMessage(info.getAddresses(), info.getFrom(), info.getCc(),
+                        info.getBcc(), info.getCaption(), info.getBody(), info.getBodyContentType(), info.getHeaders(),
+                        info.getAttachments(), attemptsCount, deadline);
 
                 sendingMessageList.add(sendingMessage);
+            }
+        } else {
+            String[] splitAddresses = info.getAddresses().split("[,;]");
+            for (String address : splitAddresses) {
+                address = address.trim();
+                if (StringUtils.isNotBlank(address)) {
+                    SendingMessage sendingMessage = convertToSendingMessage(info.getAddresses(), info.getFrom(), null,
+                            null, info.getCaption(), info.getBody(), info.getBodyContentType(), info.getHeaders(),
+                            info.getAttachments(), attemptsCount, deadline);
+
+                    sendingMessageList.add(sendingMessage);
+                }
             }
         }
         return sendingMessageList;
@@ -553,7 +563,7 @@ public class Emailer implements EmailerAPI {
         }
     }
 
-    protected SendingMessage convertToSendingMessage(String address, String from, String caption, String body,
+    protected SendingMessage convertToSendingMessage(String address, String from, String cc, String bcc, String caption, String body,
                                                      String bodyContentType,
                                                      @Nullable List<EmailHeader> headers,
                                                      @Nullable EmailAttachment[] attachments,
@@ -561,6 +571,8 @@ public class Emailer implements EmailerAPI {
         SendingMessage sendingMessage = metadata.create(SendingMessage.class);
 
         sendingMessage.setAddress(address);
+        sendingMessage.setCc(cc);
+        sendingMessage.setBcc(bcc);
         sendingMessage.setFrom(from);
         sendingMessage.setContentText(body);
         sendingMessage.setCaption(caption);

--- a/modules/global/src/com/haulmont/cuba/core/entity/SendingMessage.java
+++ b/modules/global/src/com/haulmont/cuba/core/entity/SendingMessage.java
@@ -47,6 +47,12 @@ public class SendingMessage extends StandardEntity {
     @Column(name = "ADDRESS_FROM")
     protected String from;
 
+    @Column(name = "ADDRESS_CC")
+    protected String cc;
+
+    @Column(name = "ADDRESS_BCC")
+    protected String bcc;
+
     @Column(name = "CAPTION", length = CAPTION_LENGTH)
     protected String caption;
 
@@ -197,5 +203,21 @@ public class SendingMessage extends StandardEntity {
 
     public void setBodyContentType(String bodyContentType) {
         this.bodyContentType = bodyContentType;
+    }
+
+    public String getCc() {
+        return cc;
+    }
+
+    public void setCc(String cc) {
+        this.cc = cc;
+    }
+
+    public String getBcc() {
+        return bcc;
+    }
+
+    public void setBcc(String bcc) {
+        this.bcc = bcc;
     }
 }

--- a/modules/global/src/com/haulmont/cuba/core/global/EmailInfo.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/EmailInfo.java
@@ -38,8 +38,10 @@ public class EmailInfo implements Serializable {
 
     /**
      * Recipient email addresses separated with "," or ";" symbol.
-     * flag <pre>sendInOneMessage</pre> created to have backward compatibility with CUBA 6.10.2 version and lower
-     * if <pre>sendInOneMessage = true</pre> then one message will be sent for all recipients includes cc and bcc
+     * <p>
+     * Flag {@code sendInOneMessage} is for backward compatibility with previous CUBA versions.
+     * If {@code sendInOneMessage = true} then one message will be sent for all recipients and it will include CC and BCC.
+     * Otherwise CC and BCC are ignored and multiple messages by the number of recipients in addresses will be sent.
      */
     private String addresses;
     private String cc;

--- a/modules/global/src/com/haulmont/cuba/core/global/EmailInfo.java
+++ b/modules/global/src/com/haulmont/cuba/core/global/EmailInfo.java
@@ -38,8 +38,13 @@ public class EmailInfo implements Serializable {
 
     /**
      * Recipient email addresses separated with "," or ";" symbol.
+     * flag <pre>sendInOneMessage</pre> created to have backward compatibility with CUBA 6.10.2 version and lower
+     * if <pre>sendInOneMessage = true</pre> then one message will be sent for all recipients includes cc and bcc
      */
     private String addresses;
+    private String cc;
+    private String bcc;
+    private boolean sendInOneMessage = false;
     private String caption;
     private String from;
     private String templatePath;
@@ -60,18 +65,18 @@ public class EmailInfo implements Serializable {
      *          Collections.singletonMap("some_var", some_value)
      *     );
      * }</pre>
-     *
+     * <p>
      * If you want to set content body type you can use
      * {@link #EmailInfo(String, String, String, String, String, Map, EmailAttachment...)} instead or use {@code
      * setBodyContentType()} method.
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param from                  "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
-     * @param templatePath          path to a Freemarker template which is used to create the message body. The template
-     *                              is loaded through {@link Resources} in the <b>core</b> module.
-     * @param templateParameters    map of parameters to be passed to the template
-     * @param attachments           email attachments. Omit this parameter if there are no attachments.
+     * @param addresses          comma or semicolon separated list of addresses
+     * @param caption            email subject
+     * @param from               "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
+     * @param templatePath       path to a Freemarker template which is used to create the message body. The template
+     *                           is loaded through {@link Resources} in the <b>core</b> module.
+     * @param templateParameters map of parameters to be passed to the template
+     * @param attachments        email attachments. Omit this parameter if there are no attachments.
      */
     public EmailInfo(String addresses, String caption, @Nullable String from, String templatePath,
                      Map<String, Serializable> templateParameters, EmailAttachment... attachments) {
@@ -96,14 +101,14 @@ public class EmailInfo implements Serializable {
      *     );
      * }</pre>
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param from                  "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
-     * @param bodyContentType       email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
-     * @param templatePath          path to a Freemarker template which is used to create the message body. The template
-     *                              is loaded through {@link Resources} in the <b>core</b> module.
-     * @param templateParameters    map of parameters to be passed to the template
-     * @param attachments           email attachments. Omit this parameter if there are no attachments.
+     * @param addresses          comma or semicolon separated list of addresses
+     * @param caption            email subject
+     * @param from               "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
+     * @param bodyContentType    email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
+     * @param templatePath       path to a Freemarker template which is used to create the message body. The template
+     *                           is loaded through {@link Resources} in the <b>core</b> module.
+     * @param templateParameters map of parameters to be passed to the template
+     * @param attachments        email attachments. Omit this parameter if there are no attachments.
      */
     public EmailInfo(String addresses, String caption, @Nullable String from, String bodyContentType,
                      String templatePath, Map<String, Serializable> templateParameters,
@@ -127,16 +132,16 @@ public class EmailInfo implements Serializable {
      *          "Some content"
      *     );
      * }</pre>
-     *
+     * <p>
      * If you want to set content body type you can use
      * {@link #EmailInfo(String, String, String, String, String, EmailAttachment...)} instead or use {@code
      * setBodyContentType()} method.
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param from                  "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
-     * @param body                  email body
-     * @param attachments           email attachments. Omit this parameter if there are no attachments.
+     * @param addresses   comma or semicolon separated list of addresses
+     * @param caption     email subject
+     * @param from        "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
+     * @param body        email body
+     * @param attachments email attachments. Omit this parameter if there are no attachments.
      */
     public EmailInfo(String addresses, String caption, @Nullable String from, String body, EmailAttachment... attachments) {
         this.addresses = addresses;
@@ -158,12 +163,12 @@ public class EmailInfo implements Serializable {
      *     );
      * }</pre>
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param from                  "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
-     * @param body                  email body
-     * @param bodyContentType       email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
-     * @param attachments           email attachments. Omit this parameter if there are no attachments.
+     * @param addresses       comma or semicolon separated list of addresses
+     * @param caption         email subject
+     * @param from            "from" address. If null, a default provided by {@code cuba.email.fromAddress} app property is used.
+     * @param body            email body
+     * @param bodyContentType email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
+     * @param attachments     email attachments. Omit this parameter if there are no attachments.
      */
     public EmailInfo(String addresses, String caption, @Nullable String from, String body, String bodyContentType,
                      EmailAttachment... attachments) {
@@ -184,13 +189,13 @@ public class EmailInfo implements Serializable {
      *          "Some content"
      *     );
      * }</pre>
-     *
+     * <p>
      * If you want to set content body type you can use {@link #EmailInfo(String, String, String, String)} instead or
      * use {@code setBodyContentType()} method.
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param body                  email body
+     * @param addresses comma or semicolon separated list of addresses
+     * @param caption   email subject
+     * @param body      email body
      */
     public EmailInfo(String addresses, String caption, String body) {
         this.addresses = addresses;
@@ -209,10 +214,10 @@ public class EmailInfo implements Serializable {
      *     );
      * }</pre>
      *
-     * @param addresses             comma or semicolon separated list of addresses
-     * @param caption               email subject
-     * @param body                  email body
-     * @param bodyContentType       email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
+     * @param addresses       comma or semicolon separated list of addresses
+     * @param caption         email subject
+     * @param body            email body
+     * @param bodyContentType email body like "text/plain; charset=UTF-8" or "text/html; charset=UTF-8", etc
      */
     public EmailInfo(String addresses, String caption, String body, String bodyContentType) {
         this.addresses = addresses;
@@ -297,5 +302,29 @@ public class EmailInfo implements Serializable {
 
     public void setBodyContentType(String bodyContentType) {
         this.bodyContentType = bodyContentType;
+    }
+
+    public String getCc() {
+        return cc;
+    }
+
+    public void setCc(String cc) {
+        this.cc = cc;
+    }
+
+    public String getBcc() {
+        return bcc;
+    }
+
+    public void setBcc(String bcc) {
+        this.bcc = bcc;
+    }
+
+    public boolean isSendInOneMessage() {
+        return sendInOneMessage;
+    }
+
+    public void setSendInOneMessage(boolean sendInOneMessage) {
+        this.sendInOneMessage = sendInOneMessage;
     }
 }

--- a/modules/global/src/cuba-views.xml
+++ b/modules/global/src/cuba-views.xml
@@ -201,6 +201,8 @@
 
     <view class="com.haulmont.cuba.core.entity.SendingMessage" name="sendingMessage.browse">
         <property name="address"/>
+        <property name="cc"/>
+        <property name="bcc"/>
         <property name="attachmentsName"/>
         <property name="attemptsCount"/>
         <property name="attemptsMade"/>


### PR DESCRIPTION
Need to discuss the default behaviour of sending emails with multiple addresses with CC and BCC