### PR TITLE
Entity log UI should show base entity name instead of extended entity name #1390

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/app/core/entitylog/EntityLogBrowser.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/app/core/entitylog/EntityLogBrowser.java
@@ -284,11 +284,11 @@ public class EntityLogBrowser extends AbstractWindow {
             if (metadata.getExtendedEntities().getExtendedClass(metaClass) == null) {
                 MetaClass originalMetaClass = metadata.getExtendedEntities().getOriginalOrThisMetaClass(metaClass);
                 String originalName = originalMetaClass.getName();
-                Class javaClass = metaClass.getJavaClass();
+                Class javaClass = originalMetaClass.getJavaClass();
                 if (metadata.getTools().hasCompositePrimaryKey(metaClass) && !HasUuid.class.isAssignableFrom(javaClass)) {
                     continue;
                 }
-                String caption = messages.getMessage(javaClass, javaClass.getSimpleName()) + " (" + metaClass.getName() + ")";
+                String caption = messages.getMessage(javaClass, javaClass.getSimpleName()) + " (" + originalName + ")";
                 options.put(caption, originalName);
             }
         }


### PR DESCRIPTION
Entity log UI should show base entity name instead of extended entity name #1390