### PR TITLE
Add support for flex columns in Form component

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/components/Form.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/Form.java
@@ -210,4 +210,20 @@ public interface Form extends Component, Component.BelongToFrame, Component.HasC
          */
         RIGHT
     }
+
+    /**
+     * Returns the flex layout ratio for column with a given index.
+     *
+     * @param column a column index
+     * @return lex layout ratio for column with a given index
+     */
+    float getColumnFlex(int column);
+
+    /**
+     * Set flex layout ratio for column with a given index.
+     *
+     * @param column a column index
+     * @param flex   the flex ration for the column
+     */
+    void setColumnFlex(int column, float flex);
 }

--- a/modules/gui/src/com/haulmont/cuba/gui/components/Form.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/Form.java
@@ -215,12 +215,12 @@ public interface Form extends Component, Component.BelongToFrame, Component.HasC
      * Returns the flex layout ratio for column with a given index.
      *
      * @param column a column index
-     * @return lex layout ratio for column with a given index
+     * @return flex layout ratio for column with a given index
      */
     float getColumnFlex(int column);
 
     /**
-     * Set flex layout ratio for column with a given index.
+     * Sets flex layout ratio for column with a given index.
      *
      * @param column a column index
      * @param flex   the flex ration for the column

--- a/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
+++ b/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
@@ -2916,6 +2916,7 @@
                             <xs:attribute name="width" type="xs:string"/>
                             <xs:attribute name="childrenCaptionAlignment" type="formChildrenCaptionAlignment"/>
                             <xs:attribute name="childrenCaptionWidth" type="xs:string"/>
+                            <xs:attribute name="flex" type="xs:string"/>
 
                             <xs:anyAttribute namespace="##other" processContents="lax"/>
                         </xs:complexType>

--- a/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
+++ b/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
@@ -2916,7 +2916,7 @@
                             <xs:attribute name="width" type="xs:string"/>
                             <xs:attribute name="childrenCaptionAlignment" type="formChildrenCaptionAlignment"/>
                             <xs:attribute name="childrenCaptionWidth" type="xs:string"/>
-                            <xs:attribute name="flex" type="xs:string"/>
+                            <xs:attribute name="flex" type="xs:float"/>
 
                             <xs:anyAttribute namespace="##other" processContents="lax"/>
                         </xs:complexType>

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FormLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FormLoader.java
@@ -189,8 +189,7 @@ public class FormLoader extends AbstractComponentLoader<Form> {
         if (Strings.isNullOrEmpty(componentWidth)) {
             if (columnWidth != null) {
                 component.setWidth(columnWidth);
-            }
-            if (flex != null) {
+            } else if (flex != null) {
                 component.setWidthFull();
             }
         }

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FormLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/FormLoader.java
@@ -135,13 +135,8 @@ public class FormLoader extends AbstractComponentLoader<Form> {
                 String flexAttr = columnElement.attributeValue("flex");
                 Float flex = null;
                 if (!Strings.isNullOrEmpty(flexAttr)) {
-                    try {
-                        flex = Float.parseFloat(flexAttr);
-                        if (flex > 0.0F) {
-                            resultComponent.setColumnFlex(colIndex, flex);
-                        }
-                    } catch (Exception e) {
-                    }
+                    flex = Float.parseFloat(flexAttr);
+                    resultComponent.setColumnFlex(colIndex, flex);
                 }
 
                 Iterable<ComponentPosition> columnComponents = loadComponents(columnElement, columnWidth, flex);

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebForm.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebForm.java
@@ -601,4 +601,14 @@ public class WebForm extends WebAbstractComponent<CubaFieldGroupLayout> implemen
         getOwnComponentsStream().forEach(component ->
                 ((AttachNotifier) component).detached());
     }
+
+    @Override
+    public void setColumnFlex(int column, float flex) {
+        component.setColumnExpandRatio(column, flex);
+    }
+
+    @Override
+    public float getColumnFlex(int column) {
+        return component.getColumnExpandRatio(column);
+    }
 }


### PR DESCRIPTION
The form component is a bit inflexible in the way it setups the underlying GridLayout component.. specifically it's impossible to build "flex" layouts like with the grid container.

With this PR I added a new `flex` attribute (and corresponding property in the WebForm component) that translates in calls to `set/getColumnExpandRatio` for the underlying grid container.
By default, when the user sets a `flex` attribute on the `column`, but does not set an explicit `width` for a control inside the column, the control is set fullWidth (100%) by the `FormLoader`, thus letting the user build adaptive (expandable) forms without too much hassle (because if they forgot to set `100%` on the children, the result is not what they'd expect).

An example form with 2 columns, 20% and 80% respectively:
```
            <form id="form" dataContainer="ordineDc" width="100%">
                <column flex="0.2">
                    <dateField id="dataField" property="data"/>
                    <textField id="importoField" property="importo" editable="false"/>
                </column>
                <column flex="0.8">
                    <checkBox id="apertoField" property="aperto"/>
                    <lookupPickerField id="clienteField" optionsContainer="clientesDc"
                                       property="cliente">
                        <actions>
                            <action id="lookup" type="picker_lookup"/>
                            <action id="open" type="picker_open"/>
                        </actions>
                    </lookupPickerField>
                </column>
            </form>
```
and the same but with the first column fixed at 450px while the second expandable:
```
            <form id="form" dataContainer="ordineDc" width="100%">
                <column width="450px">
                    <dateField id="dataField" property="data"/>
                    <textField id="importoField" property="importo" editable="false"/>
                </column>
                <column flex="1.0">
                    <checkBox id="apertoField" property="aperto"/>
                    <lookupPickerField id="clienteField" optionsContainer="clientesDc"
                                       property="cliente">
                        <actions>
                            <action id="lookup" type="picker_lookup"/>
                            <action id="open" type="picker_open"/>
                        </actions>
                    </lookupPickerField>
                </column>
            </form>
```