### PR TITLE
[Test refactoring] UiScreenSpec - create common method showMainWindow

### DIFF
--- a/modules/web/test/spec/cuba/gui/components/beanvalidation/DateFieldRangeTest.groovy
+++ b/modules/web/test/spec/cuba/gui/components/beanvalidation/DateFieldRangeTest.groovy
@@ -47,11 +47,9 @@ class DateFieldRangeTest extends UiScreenSpec {
     }
 
     def "futureDateField and futureOrPresentDateField range test"() {
-        given:
-        def screens = vaadinUi.screens
 
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        given:
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()
@@ -72,10 +70,7 @@ class DateFieldRangeTest extends UiScreenSpec {
 
     def "pastDateField and pastOrPresentDateField range test"() {
         given:
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()
@@ -96,10 +91,7 @@ class DateFieldRangeTest extends UiScreenSpec {
 
     def "specificFutureDateField range test"() {
         given:
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()

--- a/modules/web/test/spec/cuba/gui/components/beanvalidation/DatePickerRangeTest.groovy
+++ b/modules/web/test/spec/cuba/gui/components/beanvalidation/DatePickerRangeTest.groovy
@@ -48,10 +48,7 @@ class DatePickerRangeTest extends UiScreenSpec {
 
     def "futureDatePicker and futureOrPresentDatePicker range test"() {
         given:
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()
@@ -72,10 +69,7 @@ class DatePickerRangeTest extends UiScreenSpec {
 
     def "pastDatePicker and pasteOrPresentDatePicker range test"() {
         given:
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()
@@ -96,10 +90,7 @@ class DatePickerRangeTest extends UiScreenSpec {
 
     def "specificFutureDatePicker range test"() {
         given:
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dateValidationScreen = screens.create(DateValidationScreen)
         dateValidationScreen.show()

--- a/modules/web/test/spec/cuba/gui/components/validation/ValidatorsTest.groovy
+++ b/modules/web/test/spec/cuba/gui/components/validation/ValidatorsTest.groovy
@@ -43,10 +43,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "load validators from screen"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         when:
         def validatorsScreen = screens.create(ValidatorsScreen)
@@ -57,10 +54,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "size validator string test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -99,10 +93,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "size validator collection test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -140,10 +131,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "regexp validator text"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -176,10 +164,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "positive validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -216,10 +201,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "positiveOrZero validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -255,10 +237,7 @@ class ValidatorsTest extends UiScreenSpec {
 
     // CAUTION test depends on time duration, so if you try to debug test can be failed
     def "past validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -314,10 +293,7 @@ class ValidatorsTest extends UiScreenSpec {
 
     // CAUTION test depends on time duration, so if you try to debug test can be failed
     def "pastOrPresent validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -369,10 +345,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "notNull validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -397,10 +370,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "notEmpty validator string test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -432,10 +402,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "notEmpty validator collection test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -468,10 +435,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "notBlank validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -506,10 +470,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "negative validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -545,10 +506,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "negativeOrZero validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -584,10 +542,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "min validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -623,10 +578,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "max validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -663,10 +615,7 @@ class ValidatorsTest extends UiScreenSpec {
 
     // CAUTION test depends on time duration, so if you try to debug test can be failed
     def "future validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -703,10 +652,7 @@ class ValidatorsTest extends UiScreenSpec {
 
     // CAUTION test depends on time duration, so if you try to debug test can be failed
     def "futureOrPresent validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -743,10 +689,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "digits validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -795,10 +738,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "decimal min validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -852,10 +792,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "decimal max validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -909,10 +846,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "double min validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -966,10 +900,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "double max validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()
@@ -1023,10 +954,7 @@ class ValidatorsTest extends UiScreenSpec {
     }
 
     def "groovy script validator test"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def validatorsScreen = screens.create(ValidatorsScreen)
         validatorsScreen.show()

--- a/modules/web/test/spec/cuba/web/UiScreenSpec.groovy
+++ b/modules/web/test/spec/cuba/web/UiScreenSpec.groovy
@@ -22,7 +22,10 @@ import com.haulmont.cuba.client.sys.cache.DynamicAttributesCacheStrategy
 import com.haulmont.cuba.client.testsupport.TestUserSessionSource
 import com.haulmont.cuba.core.app.dynamicattributes.DynamicAttributesCache
 import com.haulmont.cuba.core.global.UserSessionSource
+import com.haulmont.cuba.gui.Screens
 import com.haulmont.cuba.gui.config.WindowConfig
+import com.haulmont.cuba.gui.screen.OpenMode
+import com.haulmont.cuba.gui.screen.Screen
 import com.haulmont.cuba.gui.sys.UiControllersConfiguration
 import com.haulmont.cuba.security.app.UserManagementService
 import com.haulmont.cuba.web.testsupport.proxy.TestServiceProxy
@@ -74,5 +77,15 @@ class UiScreenSpec extends WebSpec {
 
         def userSessionSource = (TestUserSessionSource) cont.getBean(UserSessionSource.class)
         userSessionSource.setSession(null)
+    }
+
+    protected Screens getScreens() {
+        vaadinUi.screens
+    }
+
+    protected Screen showMainWindow() {
+        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
+        screens.show(mainWindow)
+        mainWindow
     }
 }

--- a/modules/web/test/spec/cuba/web/components/browserframe/BrowserFrameSetAttributesTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/browserframe/BrowserFrameSetAttributesTest.groovy
@@ -29,10 +29,7 @@ class BrowserFrameSetAttributesTest extends UiScreenSpec {
     }
 
     def "Sets allow attribute to BrowserFrame"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def bfAllowScreen = screens.create(BrowserFrameAllowScreen)
         bfAllowScreen.show()
@@ -53,10 +50,7 @@ class BrowserFrameSetAttributesTest extends UiScreenSpec {
     }
 
     def "Sets referrerpolicy attribute to BrowserFrame"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def bfReferrerPolicyScreen = screens.create(BrowserFrameReferrerPolicyScreen)
         bfReferrerPolicyScreen.show()
@@ -77,10 +71,7 @@ class BrowserFrameSetAttributesTest extends UiScreenSpec {
     }
 
     def "Sets sandbox attribute to BrowserFrame"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def bfSandboxScreen = screens.create(BrowserFrameSandboxScreen)
         bfSandboxScreen.show()
@@ -101,10 +92,7 @@ class BrowserFrameSetAttributesTest extends UiScreenSpec {
     }
 
     def "Sets srcdoc attribute to BrowserFrame"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def bfSrcdocScreen = screens.create(BrowserFrameSrcdocScreen)
         bfSrcdocScreen.show()
@@ -127,10 +115,7 @@ class BrowserFrameSetAttributesTest extends UiScreenSpec {
     }
 
     def "Sets srcdocFile attribute to BrowserFrame"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def bfSrcdocFileScreen = screens.create(BrowserFrameSrcdocFileScreen)
         bfSrcdocFileScreen.show()

--- a/modules/web/test/spec/cuba/web/components/composite/CompositeComponentTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/composite/CompositeComponentTest.groovy
@@ -92,10 +92,7 @@ class CompositeComponentTest extends UiScreenSpec {
     }
 
     def "composite component containing a DataGrid with MetaClass and full path to descriptor"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def commentsScreen = screens.create(CommentScreen)
         commentsScreen.show()

--- a/modules/web/test/spec/cuba/web/components/datagrid/DataGridLoadColumnsByIncludeTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/datagrid/DataGridLoadColumnsByIncludeTest.groovy
@@ -29,10 +29,7 @@ class DataGridLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "load columns by includeAll"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dataGridScreen = screens.create(DataGridLoadColumnsByIncludeScreen)
         dataGridScreen.show()
@@ -81,10 +78,7 @@ class DataGridLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "entity with embedded property"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dataGridScreen = screens.create(DataGridLoadColumnsByIncludeScreen)
         dataGridScreen.show()
@@ -102,10 +96,7 @@ class DataGridLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "overriding columns"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def groupTableScreen = screens.create(DataGridLoadColumnsByIncludeScreen)
         groupTableScreen.show()
@@ -121,10 +112,7 @@ class DataGridLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "includeAll with non-persistent entity"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dataGridTableScreen = screens.create(DataGridLoadColumnsByIncludeScreen)
         dataGridTableScreen.show()
@@ -140,10 +128,7 @@ class DataGridLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "load columns without view"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def dataGridTableScreen = screens.create(DataGridLoadColumnsByIncludeScreen)
         dataGridTableScreen.show()

--- a/modules/web/test/spec/cuba/web/components/datefield/DateFieldDatatypeTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/datefield/DateFieldDatatypeTest.groovy
@@ -32,10 +32,7 @@ class DateFieldDatatypeTest extends UiScreenSpec {
     }
 
     def "datatype is applied from the screen descriptor"(String id, Class<Datatype> datatypeClass) {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def datatypesScreen = screens.create(DateFieldDatatypeScreen)
         datatypesScreen.show()

--- a/modules/web/test/spec/cuba/web/components/datepicker/DatePickerDatatypeTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/datepicker/DatePickerDatatypeTest.groovy
@@ -32,10 +32,7 @@ class DatePickerDatatypeTest extends UiScreenSpec {
     }
 
     def "datatype is applied from the screen descriptor"(String id, Class<Datatype> datatypeClass) {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def datatypesScreen = screens.create(DatePickerDatatypeScreen)
         datatypesScreen.show()

--- a/modules/web/test/spec/cuba/web/components/grouptable/GroupTableLoadColumnsByIncludeTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/grouptable/GroupTableLoadColumnsByIncludeTest.groovy
@@ -80,10 +80,7 @@ class GroupTableLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "entity with embedded property"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def groupTableScreen = screens.create(GroupTableLoadColumnsByIncludeScreen)
         groupTableScreen.show()
@@ -101,10 +98,7 @@ class GroupTableLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "grouping and overriding columns"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def groupTableScreen = screens.create(GroupTableLoadColumnsByIncludeScreen)
         groupTableScreen.show()
@@ -121,10 +115,7 @@ class GroupTableLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "with non persistent entity"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def groupTableScreen = screens.create(GroupTableLoadColumnsByIncludeScreen)
         groupTableScreen.show()
@@ -140,10 +131,7 @@ class GroupTableLoadColumnsByIncludeTest extends UiScreenSpec {
     }
 
     def "load columns without view"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def groupTableScreen = screens.create(GroupTableLoadColumnsByIncludeScreen)
         groupTableScreen.show()

--- a/modules/web/test/spec/cuba/web/components/slider/SliderTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/slider/SliderTest.groovy
@@ -36,10 +36,7 @@ class SliderTest extends UiScreenSpec {
     }
 
     def "Datatype is applied from the screen descriptor"(String id, Class<Datatype> datatypeClass) {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def sliderScreen = screens.create(SliderScreen)
         sliderScreen.show()
@@ -64,10 +61,7 @@ class SliderTest extends UiScreenSpec {
     }
 
     def "Value is propagated to ValueSource from Slider"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def sliderScreen = screens.create(SliderScreen)
         sliderScreen.show()
@@ -83,10 +77,7 @@ class SliderTest extends UiScreenSpec {
     }
 
     def "Value is propagated to Slider from ValueSource"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def sliderScreen = screens.create(SliderScreen)
         sliderScreen.show()

--- a/modules/web/test/spec/cuba/web/components/timefield/TimeFieldDatatypeTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/timefield/TimeFieldDatatypeTest.groovy
@@ -34,10 +34,7 @@ class TimeFieldDatatypeTest extends UiScreenSpec {
     }
 
     def "datatype is applied from the screen descriptor"(String id, Class<Datatype> datatypeClass) {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def datatypesScreen = screens.create(TimeFieldDatatypeScreen)
         datatypesScreen.show()

--- a/modules/web/test/spec/cuba/web/datacontext/CompositionScreensTest.groovy
+++ b/modules/web/test/spec/cuba/web/datacontext/CompositionScreensTest.groovy
@@ -39,10 +39,7 @@ class CompositionScreensTest extends UiScreenSpec {
     @Unroll
     def "create and immediate edit of the same nested instance"(boolean explicitParentDc) {
 
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def orderScreen = screens.create(OrderScreen)
         def order = metadata.create(Order)
@@ -88,10 +85,7 @@ class CompositionScreensTest extends UiScreenSpec {
 
     def "remove nested instance on 2nd level"() {
 
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def orderScreen = screens.create(OrderScreen)
 
@@ -136,10 +130,7 @@ class CompositionScreensTest extends UiScreenSpec {
 
     def "remove nested instance on 2nd level if the root entity did not have the full object graph"() {
 
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def orderScreen = screens.create(OrderScreen)
 

--- a/modules/web/test/spec/cuba/web/dialogs/DialogModeTest.groovy
+++ b/modules/web/test/spec/cuba/web/dialogs/DialogModeTest.groovy
@@ -30,10 +30,7 @@ class DialogModeTest extends UiScreenSpec {
     }
 
     def 'DialogMode supports AUTO width and height'() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(DialogAutoSizeTestScreen)
         screen.show()
@@ -49,10 +46,7 @@ class DialogModeTest extends UiScreenSpec {
     }
 
     def 'DialogMode supports specified width and height'() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(DialogSpecifiedSizeTestScreen)
         screen.show()

--- a/modules/web/test/spec/cuba/web/dialogs/InputDialogTest.groovy
+++ b/modules/web/test/spec/cuba/web/dialogs/InputDialogTest.groovy
@@ -19,12 +19,12 @@ package spec.cuba.web.dialogs
 import com.google.common.base.Strings
 import com.haulmont.chile.core.datatypes.DatatypeRegistry
 import com.haulmont.chile.core.datatypes.impl.*
+import com.haulmont.cuba.gui.Dialogs
 import com.haulmont.cuba.gui.app.core.inputdialog.DialogActions
 import com.haulmont.cuba.gui.app.core.inputdialog.InputDialog
 import com.haulmont.cuba.gui.app.core.inputdialog.InputParameter
 import com.haulmont.cuba.gui.components.*
 import com.haulmont.cuba.gui.components.inputdialog.InputDialogAction
-import com.haulmont.cuba.gui.screen.OpenMode
 import com.haulmont.cuba.gui.screen.Screen
 import com.haulmont.cuba.web.testmodel.sales.Status
 import com.haulmont.cuba.web.testmodel.sample.GoodInfo
@@ -39,18 +39,19 @@ import static com.haulmont.cuba.gui.screen.UiControllerUtils.getScreenContext
 
 class InputDialogTest extends UiScreenSpec {
 
+    Dialogs dialogs
+    Screen mainWindow
+
     @SuppressWarnings("GroovyAssignabilityCheck")
     void setup() {
         exportScreensPackages(['com.haulmont.cuba.gui.app'])
+
+        mainWindow = showMainWindow()
+
+        dialogs = getScreenContext(mainWindow).getDialogs()
     }
 
     def "input parameter ids should be different"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         when: "the same id is used"
         dialogs.createInputDialog(mainWindow)
@@ -74,12 +75,6 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "input parameter types are presented"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         when: "all types are used"
         InputDialog dialog = dialogs.createInputDialog(mainWindow)
@@ -128,12 +123,6 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "default actions are created"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         when: "YES NO CANCEL are created"
         InputDialog dialog = dialogs.createInputDialog(mainWindow)
@@ -163,12 +152,8 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "default actions with result handler"() {
-        def screens = vaadinUi.screens
 
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
+        given:
 
         def goodInfo = new GoodInfo()
         def defaultString = "default value"
@@ -205,12 +190,9 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "custom input dialog actions"() {
-        def screens = vaadinUi.screens
 
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        given:
 
-        def dialogs = getScreenContext(mainWindow).getDialogs()
         def dateValue = new Date()
         def stringValue = "Default value"
 
@@ -247,13 +229,9 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "open with close listener"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
 
         when: "check closing with OK action"
-        def dialog = (InputDialog) createDialogWithCloseListener(mainWindow)
+        def dialog = (InputDialog) createDialogWithCloseListener()
 
         then:
         def okBtn = getButtonFromDialog(dialog, 1) // because 0 - spacer
@@ -262,7 +240,7 @@ class InputDialogTest extends UiScreenSpec {
         !screens.getOpenedScreens().getActiveScreens().contains(dialog)
 
         when: "check closing with CANCEL action"
-        def cancelDialog = (InputDialog) createDialogWithCloseListener(mainWindow)
+        def cancelDialog = (InputDialog) createDialogWithCloseListener()
 
         then:
         def cancelBtn = getButtonFromDialog(cancelDialog, 2)
@@ -271,8 +249,7 @@ class InputDialogTest extends UiScreenSpec {
         !screens.getOpenedScreens().getActiveScreens().contains(dialog)
     }
 
-    protected InputDialog createDialogWithCloseListener(Screen mainWindow) {
-        def dialogs = getScreenContext(mainWindow).getDialogs()
+    protected InputDialog createDialogWithCloseListener() {
         def bigDecimalValue = 1234
 
         return dialogs.createInputDialog(mainWindow)
@@ -291,12 +268,9 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "input parameter with custom field"() {
-        def screens = vaadinUi.screens
 
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        given:
 
-        def dialogs = getScreenContext(mainWindow).getDialogs()
         def customValue = "default value"
         def dateTimeValue = new Date()
 
@@ -321,13 +295,7 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "field validation"() {
-        def screens = vaadinUi.screens
         def datatypeRegistry = cont.getBean(DatatypeRegistry)
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         when: "custom field has incorrect value"
         InputDialog dialog = dialogs.createInputDialog(mainWindow)
@@ -361,12 +329,6 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "validator and default DialogActions"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
-
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         when: "create dialog with default actions and custom validator"
         InputDialog dialog = dialogs.createInputDialog(mainWindow)
@@ -391,13 +353,8 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "validator and validationRequired in InputDialogAction"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
 
         when: "validator and validationRequired in InputDialogAction"
-        def dialogs = getScreenContext(mainWindow).getDialogs()
         def targetValue = 100100
         def date = new Date(targetValue)
 
@@ -438,13 +395,8 @@ class InputDialogTest extends UiScreenSpec {
     }
 
     def "enum input parameter"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
 
         when: "validator and validationRequired in InputDialogAction"
-        def dialogs = getScreenContext(mainWindow).getDialogs()
 
         InputDialog dialog = dialogs.createInputDialog(mainWindow)
                 .withParameters(enumParameter("enumField", Status)

--- a/modules/web/test/spec/cuba/web/masterdetail/MasterDetailInitEntityTest.groovy
+++ b/modules/web/test/spec/cuba/web/masterdetail/MasterDetailInitEntityTest.groovy
@@ -32,10 +32,7 @@ class MasterDetailInitEntityTest extends UiScreenSpec {
     }
 
     def "MasterDetailScreen fires InitEntityEvent on Create"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def initEntityListener = Mock(Consumer)
 

--- a/modules/web/test/spec/cuba/web/screens/ScreenOpenedClosedEvtTest.groovy
+++ b/modules/web/test/spec/cuba/web/screens/ScreenOpenedClosedEvtTest.groovy
@@ -24,10 +24,7 @@ import spec.cuba.web.menu.commandtargets.TestWebBean
 class ScreenOpenedClosedEvtTest extends UiScreenSpec {
 
     def 'ScreenOpenedEvent is fired'() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def testWebBean = cont.getBean(TestWebBean)
 
@@ -40,10 +37,7 @@ class ScreenOpenedClosedEvtTest extends UiScreenSpec {
     }
 
     def 'ScreenClosedEvent is fired'() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def testWebBean = cont.getBean(TestWebBean)
 

--- a/modules/web/test/spec/cuba/web/view/ScreenViewTest.groovy
+++ b/modules/web/test/spec/cuba/web/view/ScreenViewTest.groovy
@@ -17,7 +17,6 @@
 package spec.cuba.web.view
 
 
-import com.haulmont.cuba.gui.screen.OpenMode
 import com.haulmont.cuba.security.entity.User
 import spec.cuba.web.UiScreenSpec
 import spec.cuba.web.view.screens.UserEditEmbeddedViewScreen
@@ -30,10 +29,9 @@ class ScreenViewTest extends UiScreenSpec {
     }
 
     def "Embedded view initialized in instance container"() {
-        def screens = vaadinUi.screens
 
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        given:
+        showMainWindow()
 
         when: "show screen"
 
@@ -76,5 +74,6 @@ class ScreenViewTest extends UiScreenSpec {
         userRolesViewProperty.view.properties.find { it.name == "role" } != null
 
     }
+
 
 }

--- a/modules/web/test/spec/cuba/web/workarea/TabWindowPropertiesTest.groovy
+++ b/modules/web/test/spec/cuba/web/workarea/TabWindowPropertiesTest.groovy
@@ -35,10 +35,7 @@ class TabWindowPropertiesTest extends UiScreenSpec {
     }
 
     def "change window caption from screen"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(TabbedScreen)
         def window = screen.getWindow()
@@ -73,10 +70,7 @@ class TabWindowPropertiesTest extends UiScreenSpec {
     }
 
     def "change window description from screen"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(TabbedScreen)
         def window = screen.getWindow()
@@ -105,10 +99,7 @@ class TabWindowPropertiesTest extends UiScreenSpec {
 
     @SuppressWarnings("GroovyPointlessBoolean")
     def "change window closeable from screen"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(TabbedScreen)
         def window = screen.getWindow()
@@ -136,10 +127,7 @@ class TabWindowPropertiesTest extends UiScreenSpec {
 
     @SuppressWarnings("GroovyPointlessBoolean")
     def "change window icon from screen"() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def screen = screens.create(TabbedScreen)
         def window = screen.getWindow()

--- a/modules/web/test/spec/cuba/web/workarea/WorkAreaTabChangedEvtTest.groovy
+++ b/modules/web/test/spec/cuba/web/workarea/WorkAreaTabChangedEvtTest.groovy
@@ -24,10 +24,7 @@ import spec.cuba.web.menu.commandtargets.TestWebBean
 class WorkAreaTabChangedEvtTest extends UiScreenSpec {
 
     def 'WorkAreaTabChangedEvent is fired when screen is opened or closed'() {
-        def screens = vaadinUi.screens
-
-        def mainWindow = screens.create("mainWindow", OpenMode.ROOT)
-        screens.show(mainWindow)
+        showMainWindow()
 
         def testWebBean = cont.getBean(TestWebBean)
 


### PR DESCRIPTION
## UiScreenSpec - create common method showMainWindow
As part of my participation in [Hacktoberfest](https://hacktoberfest.digitalocean.com/) I took the time to take a look at the test cases and came up with the following improvement:

* The UiScreenSpec has now a new common method `showMainWindow`
* the duplicated code in the test cases to create the main window have been removed