### PR TITLE
[Test refactoring] CreateComponentTest - use Spocks @Unroll feature

### DIFF
--- a/modules/web/test/spec/cuba/web/components/CreateComponentTest.groovy
+++ b/modules/web/test/spec/cuba/web/components/CreateComponentTest.groovy
@@ -21,11 +21,13 @@ import com.haulmont.cuba.gui.components.*
 import com.haulmont.cuba.gui.components.mainwindow.*
 import com.haulmont.cuba.web.gui.components.JavaScriptComponent
 import spec.cuba.web.WebSpec
+import spock.lang.Unroll
 
 @SuppressWarnings("GroovyAccessibility")
 class CreateComponentTest extends WebSpec {
 
-    def "create all standard UI components with UiComponents"() {
+    @Unroll
+    def "create standard UI component: '#name' with UiComponents"() {
         expect:
         uiComponents.create(name) != null
 
@@ -123,14 +125,20 @@ class CreateComponentTest extends WebSpec {
         ]
     }
 
-    def "create all standard facets with Facets"() {
+    @Unroll
+    def "create standard facet: '#facet' with Facets"() {
+
+        given:
+
         def facets = cont.getBean(Facets.class)
 
         expect:
-        facets.create(clazz) != null
+
+        facets.create(facet) != null
 
         where:
-        clazz << [
+
+        facet << [
                 Timer.class,
                 ClipboardTrigger.class
         ]


### PR DESCRIPTION
## CreateComponentTest - Use Spock @Unroll feature
As part of my participation in [Hacktoberfest](https://hacktoberfest.digitalocean.com/) I took the time to take a look at the test cases and came up with the following improvement:

* The CreateComponentTest now uses the `@Unroll` feature of spock to have better test case names