### PR TITLE
Store original exception in error results of Bean scheduled tasks

### DIFF
--- a/modules/core/src/com/haulmont/cuba/core/app/scheduling/RunnerBean.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/scheduling/RunnerBean.java
@@ -239,7 +239,9 @@ public class RunnerBean implements Runner {
 
                     Method method = bean.getClass().getMethod(task.getMethodName(), paramTypes);
                     return method.invoke(bean, paramValues);
-                } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                } catch (InvocationTargetException e) {
+                    throw new RuntimeException(e.getCause());
+                } catch (NoSuchMethodException | IllegalAccessException e) {
                     throw new RuntimeException(e);
                 }
             }


### PR DESCRIPTION
Fix the problem described in issue #2617