### PR TITLE
Resolve the problem that @Install for DataContainer doesn't work

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/sys/UiControllerDependencyInjector.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/sys/UiControllerDependencyInjector.java
@@ -239,6 +239,8 @@ public class UiControllerDependencyInjector implements ControllerDependencyInjec
             }
         } else if (annotation.target() == Target.DATA_LOADER) {
             targetInstance = getScreenData(frameOwner).getLoader(target);
+        } else if (annotation.target() == Target.DATA_CONTAINER) {
+            targetInstance = getScreenData(frameOwner).getContainer(target);
         } else {
             targetInstance = findMethodTarget(frame, target);
         }


### PR DESCRIPTION
Code snippet to reproduce the problem:
```
@Install(to = "ordersBrowseDc", target = Target.DATA_CONTAINER, subject = "sorter")
protected void ordersBrowseDcSorter(Sort sort) {
        
}
```