### PR TITLE
Add CUBA support for QueryDSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,12 +341,17 @@ configure(globalModule) {
         compile(bom['javax.inject:javax.inject'])
         compile(bom['javax.annotation:javax.annotation-api'])
         compileOnly(bom['javax.servlet:javax.servlet-api'])
+
+        compile(bom['com.querydsl:querydsl-jpa'])
+        annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', version: '4.1.4', classifier: 'jpa'
+        annotationProcessor configurations.compile
     }
 
     task generateReleaseTimestamp(type: CubaReleaseTimeStamp) {
         releaseTimeStampPath = "$buildDir/release-number/com/haulmont/cuba/core/global/release.timestamp"
         releaseNumberPath = "$buildDir/release-number/com/haulmont/cuba/core/global/release.number"
     }
+
     // do not use classes directory, because it will break Gradle task UP-TO-DATE caching
     jar {
         from new File(project.buildDir, 'release-number')

--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ configure(globalModule) {
         compile(bom['javax.annotation:javax.annotation-api'])
         compileOnly(bom['javax.servlet:javax.servlet-api'])
 
-        compile(bom['com.querydsl:querydsl-jpa'])
+        compileOnly(bom['com.querydsl:querydsl-jpa'])
         annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', version: '4.1.4', classifier: 'jpa'
         annotationProcessor configurations.compile
     }

--- a/modules/global/src/com/haulmont/cuba/bom.properties
+++ b/modules/global/src/com/haulmont/cuba/bom.properties
@@ -147,3 +147,5 @@ org.mindrot/jbcrypt = 0.4
 com.zaxxer/HikariCP = 3.4.1
 
 com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer = 20191001.1
+
+com.querydsl/querydsl-jpa = 4.1.4


### PR DESCRIPTION
Hi,

I have AppComponent to adding QueryDSL support to CUBA. But this component doesn't work without classes generated by QueryDSL annotation processor. I can not generate classes into app component gradle configuration because annotation processor is needed in sources.

I see some solutions:
1. Add QueryDSL annotation processor to the compile step of global module. The solution is presented in the PR
2. Add additional jar to CUBA gradle configuration wich will collect to QueryDSL generated classes. The name can be like cuba-global-querydsl or cuba-global with querydsl classifier. But there are some problems. One of them that annotation processor doesn't modify SourceSet and it is difucult to collect only QueryDSL generated classes
3. Fork CUBA.platform and create own gradle configuration which will generate own global artifact and publish the artifact with my own maven groupId