### PR TITLE
Fix typo in WebTokenList.setLookupFieldOptionsCaptionProvider method

### DIFF
--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebTokenList.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebTokenList.java
@@ -245,7 +245,7 @@ public class WebTokenList<V extends Entity>
 
     @Override
     public void setLookupFieldOptionsCaptionProvider(Function<? super V, String> optionsCaptionProvider) {
-        lookupPickerField.setOptionCaptionProvider(optionCaptionProvider);
+        lookupPickerField.setOptionCaptionProvider(optionsCaptionProvider);
     }
 
     @Override


### PR DESCRIPTION
Fix the problem described in issue #2738