### PR TITLE
Add docking for Vertical SplitPanel

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/components/SplitPanel.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/SplitPanel.java
@@ -39,8 +39,8 @@ public interface SplitPanel extends ComponentContainer, Component.BelongToFrame,
     enum DockMode {
         LEFT,
         RIGHT,
-        UP,
-        DOWN
+        TOP,
+        BOTTOM
     }
 
     int getOrientation();

--- a/modules/gui/src/com/haulmont/cuba/gui/components/SplitPanel.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/components/SplitPanel.java
@@ -38,7 +38,9 @@ public interface SplitPanel extends ComponentContainer, Component.BelongToFrame,
      */
     enum DockMode {
         LEFT,
-        RIGHT
+        RIGHT,
+        UP,
+        DOWN
     }
 
     int getOrientation();
@@ -182,8 +184,6 @@ public interface SplitPanel extends ComponentContainer, Component.BelongToFrame,
 
     /**
      * Enables or disables SplitPanel dock button.
-     * <p>
-     * Notice that docking is available only for horizontally oriented SplitPanel.
      *
      * @param dockable dockable
      */
@@ -196,15 +196,13 @@ public interface SplitPanel extends ComponentContainer, Component.BelongToFrame,
 
     /**
      * Sets docking direction.
-     * <p>
-     * Notice that docking is available only for horizontally oriented SplitPanel.
      *
      * @param dockMode one of {@link DockMode} options
      */
     void setDockMode(DockMode dockMode);
 
     /**
-     * @return docking direction or null in case of vertically oriented SplitPanel
+     * @return docking direction
      */
     @Nullable
     DockMode getDockMode();

--- a/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
+++ b/modules/gui/src/com/haulmont/cuba/gui/screen/layout.xsd
@@ -26,6 +26,8 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="LEFT"/>
             <xs:enumeration value="RIGHT"/>
+            <xs:enumeration value="TOP"/>
+            <xs:enumeration value="BOTTOM"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/SplitPanelLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/SplitPanelLoader.java
@@ -102,7 +102,7 @@ public class SplitPanelLoader extends ContainerLoader<SplitPanel> {
             && (mode == SplitPanel.DockMode.LEFT || mode == SplitPanel.DockMode.RIGHT)) {
             throw new GuiDevelopmentException("Dock mode " + mode.name() + " cannot be enabled for vertically oriented SplitPanel", context);
         } else if (resultComponent.getOrientation() == SplitPanel.ORIENTATION_HORIZONTAL
-                && (mode == SplitPanel.DockMode.UP || mode == SplitPanel.DockMode.DOWN)) {
+                && (mode == SplitPanel.DockMode.TOP || mode == SplitPanel.DockMode.BOTTOM)) {
             throw new GuiDevelopmentException("Dock mode " + mode.name() + " cannot be enabled for horizontally oriented SplitPanel", context);
         }
 

--- a/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/SplitPanelLoader.java
+++ b/modules/gui/src/com/haulmont/cuba/gui/xml/layout/loaders/SplitPanelLoader.java
@@ -86,10 +86,6 @@ public class SplitPanelLoader extends ContainerLoader<SplitPanel> {
         }
 
         boolean bDockable = Boolean.parseBoolean(dockable);
-        if (bDockable && resultComponent.getOrientation() == SplitPanel.ORIENTATION_VERTICAL) {
-            throw new GuiDevelopmentException("Docking cannot be enabled for vertically oriented SplitPanel", context);
-        }
-
         resultComponent.setDockable(bDockable);
     }
 
@@ -100,11 +96,16 @@ public class SplitPanelLoader extends ContainerLoader<SplitPanel> {
             return;
         }
 
-        if (resultComponent.getOrientation() == SplitPanel.ORIENTATION_VERTICAL) {
-            throw new GuiDevelopmentException("Docking cannot be enabled for vertically oriented SplitPanel", context);
+        SplitPanel.DockMode mode = SplitPanel.DockMode.valueOf(dockMode);
+
+        if (resultComponent.getOrientation() == SplitPanel.ORIENTATION_VERTICAL
+            && (mode == SplitPanel.DockMode.LEFT || mode == SplitPanel.DockMode.RIGHT)) {
+            throw new GuiDevelopmentException("Dock mode " + mode.name() + " cannot be enabled for vertically oriented SplitPanel", context);
+        } else if (resultComponent.getOrientation() == SplitPanel.ORIENTATION_HORIZONTAL
+                && (mode == SplitPanel.DockMode.UP || mode == SplitPanel.DockMode.DOWN)) {
+            throw new GuiDevelopmentException("Dock mode " + mode.name() + " cannot be enabled for horizontally oriented SplitPanel", context);
         }
 
-        SplitPanel.DockMode mode = SplitPanel.DockMode.valueOf(dockMode);
         resultComponent.setDockMode(mode);
     }
 

--- a/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaHorizontalSplitPanelConnector.java
+++ b/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaHorizontalSplitPanelConnector.java
@@ -35,7 +35,7 @@ public class CubaHorizontalSplitPanelConnector extends HorizontalSplitPanelConne
         super.init();
 
         getWidget().beforeDockPositionHandler =
-                position -> getRpcProxy(CubaHorizontalSplitPanelServerRpc.class).setBeforeDockPosition(position);
+                position -> getRpcProxy(CubaDockableSplitPanelServerRpc.class).setBeforeDockPosition(position);
     }
 
     @Override

--- a/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelConnector.java
+++ b/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelConnector.java
@@ -34,7 +34,7 @@ public class CubaVerticalSplitPanelConnector extends VerticalSplitPanelConnector
         super.init();
 
         getWidget().beforeDockPositionHandler =
-                position -> getRpcProxy(CubaHorizontalSplitPanelServerRpc.class).setBeforeDockPosition(position);
+                position -> getRpcProxy(CubaDockableSplitPanelServerRpc.class).setBeforeDockPosition(position);
     }
 
     @Override

--- a/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelConnector.java
+++ b/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelConnector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.web.widgets.client.split;
+
+import com.google.gwt.core.client.Scheduler;
+import com.haulmont.cuba.web.widgets.CubaVerticalSplitPanel;
+import com.vaadin.client.communication.StateChangeEvent;
+import com.vaadin.client.ui.PostLayoutListener;
+import com.vaadin.client.ui.splitpanel.VerticalSplitPanelConnector;
+import com.vaadin.shared.ui.Connect;
+
+@Connect(value = CubaVerticalSplitPanel.class, loadStyle = Connect.LoadStyle.EAGER)
+public class CubaVerticalSplitPanelConnector extends VerticalSplitPanelConnector
+        implements PostLayoutListener {
+
+    protected boolean updateLayout = false;
+
+    @Override
+    protected void init() {
+        super.init();
+
+        getWidget().beforeDockPositionHandler =
+                position -> getRpcProxy(CubaHorizontalSplitPanelServerRpc.class).setBeforeDockPosition(position);
+    }
+
+    @Override
+    public CubaVerticalSplitPanelState getState() {
+        return (CubaVerticalSplitPanelState) super.getState();
+    }
+
+    @Override
+    public CubaVerticalSplitPanelWidget getWidget() {
+        return (CubaVerticalSplitPanelWidget) super.getWidget();
+    }
+
+    @Override
+    public void onStateChanged(StateChangeEvent stateChangeEvent) {
+        super.onStateChanged(stateChangeEvent);
+
+        if (stateChangeEvent.hasPropertyChanged("dockable")) {
+            getWidget().setDockable(getState().dockable);
+        }
+        if (stateChangeEvent.hasPropertyChanged("dockMode")) {
+            getWidget().setDockMode(getState().dockMode);
+        }
+        if (stateChangeEvent.hasPropertyChanged("defaultPosition")) {
+            getWidget().defaultPosition = getState().defaultPosition;
+        }
+        if (stateChangeEvent.hasPropertyChanged("beforeDockPosition")) {
+            getWidget().beforeDockPosition = getState().beforeDockPosition;
+        }
+
+        updateLayout = true;
+    }
+
+    @Override
+    public void postLayout() {
+        // Have to re-layout after parent layout expand hack applied
+        // to avoid split position glitch.
+        if (updateLayout) {
+            Scheduler.get().scheduleFinally(this::layout);
+            updateLayout = false;
+        }
+    }
+}

--- a/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelWidget.java
+++ b/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelWidget.java
@@ -52,7 +52,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
 
     protected DockButtonState dockButtonState = DockButtonState.UP;
 
-    protected SplitPanelDockMode dockMode = SplitPanelDockMode.UP;
+    protected SplitPanelDockMode dockMode = SplitPanelDockMode.TOP;
 
     protected Consumer<String> beforeDockPositionHandler = null;
 
@@ -92,7 +92,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
     protected CubaPlaceHolderWidget createDockButton() {
         CubaPlaceHolderWidget dockBtn = new CubaPlaceHolderWidget();
         dockBtn.setStyleName(SP_DOCK_BUTTON);
-        if (dockMode == SplitPanelDockMode.UP) {
+        if (dockMode == SplitPanelDockMode.TOP) {
             dockBtn.addStyleName(SP_DOCK_BUTTON_UP);
         } else {
             dockBtn.addStyleName(SP_DOCK_BUTTON_DOWN);
@@ -108,9 +108,9 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
         dockBtnContainer.getStyle().setZIndex(101);
         dockBtnContainer.getStyle().setPosition(Style.Position.ABSOLUTE);
 
-        if (dockMode == SplitPanelDockMode.UP) {
+        if (dockMode == SplitPanelDockMode.TOP) {
             dockBtnContainer.addClassName(SP_DOCK_UP);
-        } else if (dockMode == SplitPanelDockMode.DOWN) {
+        } else if (dockMode == SplitPanelDockMode.BOTTOM) {
             dockBtnContainer.addClassName(SP_DOCK_DOWN);
         }
         return dockBtnContainer;
@@ -120,7 +120,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
         String newPosition = position;
         boolean isDocked = false;
 
-        if (dockMode == SplitPanelDockMode.UP) {
+        if (dockMode == SplitPanelDockMode.TOP) {
             if (dockButtonState == DockButtonState.UP) {
                 defaultPosition = position;
                 newPosition = "0px";
@@ -138,7 +138,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
                 newPosition = reversed ? "0px" : getAbsoluteBottom() + "px";
                 isDocked = true;
             }
-        } else if (dockMode == SplitPanelDockMode.DOWN) {
+        } else if (dockMode == SplitPanelDockMode.BOTTOM) {
             if (dockButtonState == DockButtonState.DOWN) {
                 defaultPosition = position;
                 newPosition = reversed ? "0px" : getAbsoluteBottom() + "px";
@@ -175,7 +175,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
         if (isDockable()) {
 
             Style dockButtonStyle = dockButtonContainer.getStyle();
-            if (dockMode == SplitPanelDockMode.UP) {
+            if (dockMode == SplitPanelDockMode.TOP) {
                 int top = splitter.getOffsetTop();
                 if (top > BUTTON_HEIGHT_SPACE) {
                     dockButtonStyle.setTop(top - (dockButton.getOffsetHeight() - getSplitterSize()), Style.Unit.PX);
@@ -198,7 +198,7 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
 
                     updateSplitPanelStyle(SP_DOCKABLE_DOWN, SP_DOCKABLE_UP);
                 }
-            } else if (dockMode == SplitPanelDockMode.DOWN) {
+            } else if (dockMode == SplitPanelDockMode.BOTTOM) {
                 int down = splitter.getOffsetTop() + splitter.getOffsetHeight();
                 int splitBottomPosition = getAbsoluteBottom();
 
@@ -288,21 +288,21 @@ public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
     }
 
     protected boolean isMinPositionSet() {
-        return dockMode == SplitPanelDockMode.UP
+        return dockMode == SplitPanelDockMode.TOP
                 && !minimumPosition.equals("0%")
                 && !minimumPosition.equals("0px");
     }
 
     protected boolean isMaxPositionSet() {
-        return dockMode == SplitPanelDockMode.DOWN
+        return dockMode == SplitPanelDockMode.BOTTOM
                 && !maximumPosition.equals("100%")
                 && !maximumPosition.equals(getAbsoluteBottom() + "px");
     }
 
     protected boolean isExtremePosition(String pos) {
-        boolean dockedToLeft = dockMode == SplitPanelDockMode.UP
+        boolean dockedToLeft = dockMode == SplitPanelDockMode.TOP
                 && (pos.equals("0%") || pos.equals("0px"));
-        boolean dockedToRight = dockMode == SplitPanelDockMode.DOWN
+        boolean dockedToRight = dockMode == SplitPanelDockMode.BOTTOM
                 && (pos.equals("100%") || pos.equals(getAbsoluteBottom() + "px"));
         return dockedToLeft || dockedToRight;
     }

--- a/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelWidget.java
+++ b/modules/web-toolkit/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelWidget.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2008-2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.web.widgets.client.split;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.haulmont.cuba.web.widgets.client.placeholder.CubaPlaceHolderWidget;
+import com.vaadin.client.ui.VSplitPanelVertical;
+
+import java.util.function.Consumer;
+
+public class CubaVerticalSplitPanelWidget extends VSplitPanelVertical {
+
+    /**
+     * Styles for widget
+     */
+    protected static final String SP_DOCK_BUTTON = "c-splitpanel-dock-button-vertical";
+    protected static final String SP_DOCK_BUTTON_UP = "c-splitpanel-dock-button-up";
+    protected static final String SP_DOCK_BUTTON_DOWN = "c-splitpanel-dock-button-down";
+    protected static final String SP_DOCK_UP = "c-splitpanel-dock-up";
+    protected static final String SP_DOCK_DOWN = "c-splitpanel-dock-down";
+    protected static final String SP_DOCKABLE_UP = "c-splitpanel-dockable-up";
+    protected static final String SP_DOCKABLE_DOWN = "c-splitpanel-dockable-down";
+
+    protected static final int BUTTON_HEIGHT_SPACE = 12;
+    protected boolean reversed;
+    protected boolean docked;
+
+    protected int splitWidth;
+
+    protected enum DockButtonState {
+        UP,
+        DOWN
+    }
+
+    protected DockButtonState dockButtonState = DockButtonState.UP;
+
+    protected SplitPanelDockMode dockMode = SplitPanelDockMode.UP;
+
+    protected Consumer<String> beforeDockPositionHandler = null;
+
+    protected String defaultPosition = null;
+    protected String beforeDockPosition = null;
+
+    private Element dockButtonContainer;
+    private CubaPlaceHolderWidget dockButton;
+
+    public boolean isDockable() {
+        return dockButtonContainer != null;
+    }
+
+    public void setDockable(boolean dockable) {
+        if (isDockable() == dockable) {
+            return;
+        }
+
+        if (dockable) {
+            dockButton = createDockButton();
+            dockButtonContainer = createDockButtonContainer();
+
+            add(dockButton, dockButtonContainer);
+            splitter.getParentElement().appendChild(dockButtonContainer);
+
+            updateDockButtonPosition();
+        } else {
+            if (dockButtonContainer != null) {
+                dockButtonContainer.removeFromParent();
+
+                dockButtonContainer = null;
+                dockButton = null;
+            }
+        }
+    }
+
+    protected CubaPlaceHolderWidget createDockButton() {
+        CubaPlaceHolderWidget dockBtn = new CubaPlaceHolderWidget();
+        dockBtn.setStyleName(SP_DOCK_BUTTON);
+        if (dockMode == SplitPanelDockMode.UP) {
+            dockBtn.addStyleName(SP_DOCK_BUTTON_UP);
+        } else {
+            dockBtn.addStyleName(SP_DOCK_BUTTON_DOWN);
+        }
+        dockBtn.addDomHandler(
+                event -> onDockButtonClick(),
+                ClickEvent.getType());
+        return dockBtn;
+    }
+
+    protected Element createDockButtonContainer() {
+        Element dockBtnContainer = DOM.createDiv();
+        dockBtnContainer.getStyle().setZIndex(101);
+        dockBtnContainer.getStyle().setPosition(Style.Position.ABSOLUTE);
+
+        if (dockMode == SplitPanelDockMode.UP) {
+            dockBtnContainer.addClassName(SP_DOCK_UP);
+        } else if (dockMode == SplitPanelDockMode.DOWN) {
+            dockBtnContainer.addClassName(SP_DOCK_DOWN);
+        }
+        return dockBtnContainer;
+    }
+
+    private void onDockButtonClick() {
+        String newPosition = position;
+        boolean isDocked = false;
+
+        if (dockMode == SplitPanelDockMode.UP) {
+            if (dockButtonState == DockButtonState.UP) {
+                defaultPosition = position;
+                newPosition = "0px";
+                isDocked = true;
+            } else if (defaultPosition != null) {
+                newPosition = defaultPosition;
+            } else if (beforeDockPosition != null) {
+                // apply last saved position if defaultPosition is null
+                newPosition = beforeDockPosition;
+            } else if (isSplitterInBottomChangeArea()) {
+                // splitter is placed in the absolute UP position and if we click on the dock button
+                // it won't be replaced, because of defaultPosition and beforeDockPosition are null.
+                // So we replace it to the absolute DOWN position.
+                defaultPosition = position;
+                newPosition = reversed ? "0px" : getAbsoluteBottom() + "px";
+                isDocked = true;
+            }
+        } else if (dockMode == SplitPanelDockMode.DOWN) {
+            if (dockButtonState == DockButtonState.DOWN) {
+                defaultPosition = position;
+                newPosition = reversed ? "0px" : getAbsoluteBottom() + "px";
+                isDocked = true;
+            } else if (defaultPosition != null) {
+                newPosition = defaultPosition;
+            } else if (beforeDockPosition != null) {
+                // apply last saved position if defaultPosition is null
+                newPosition = beforeDockPosition;
+            } else if (isSplitterInTopChangeArea()) {
+                // splitter is placed in the absolute DOWN position and if we click on the dock button
+                // it won't be replaced, because of defaultPosition and beforeDockPosition are null.
+                // So we replace it to the absolute UP position.
+                defaultPosition = position;
+                newPosition = "0px";
+                isDocked = true;
+            }
+        }
+
+        // save last position before dock changes position
+        beforeDockPositionHandler.accept(defaultPosition);
+        setDocked(isDocked);
+        setSplitPosition(newPosition);
+        fireEvent(new SplitterMoveHandler.SplitterMoveEvent(this));
+    }
+
+    public void setDockMode(SplitPanelDockMode dockMode) {
+        this.dockMode = dockMode;
+
+        updateDockButtonPosition();
+    }
+
+    protected void updateDockButtonPosition() {
+        if (isDockable()) {
+
+            Style dockButtonStyle = dockButtonContainer.getStyle();
+            if (dockMode == SplitPanelDockMode.UP) {
+                int top = splitter.getOffsetTop();
+                if (top > BUTTON_HEIGHT_SPACE) {
+                    dockButtonStyle.setTop(top - (dockButton.getOffsetHeight() - getSplitterSize()), Style.Unit.PX);
+                    dockButtonStyle.setLeft(getDockBtnContainerHorizontalPosition(), Style.Unit.PX);
+
+                    if (dockButtonState == DockButtonState.DOWN) {
+                        updateDockButtonStyle(SP_DOCK_BUTTON_UP, SP_DOCK_BUTTON_DOWN);
+                        dockButtonState = DockButtonState.UP;
+                    }
+
+                    updateSplitPanelStyle(SP_DOCKABLE_UP, SP_DOCKABLE_DOWN);
+                } else {
+                    dockButtonStyle.setTop(top, Style.Unit.PX);
+                    dockButtonStyle.setLeft(getDockBtnContainerHorizontalPosition(), Style.Unit.PX);
+
+                    if (dockButtonState == DockButtonState.UP) {
+                        updateDockButtonStyle(SP_DOCK_BUTTON_DOWN, SP_DOCK_BUTTON_UP);
+                        dockButtonState = DockButtonState.DOWN;
+                    }
+
+                    updateSplitPanelStyle(SP_DOCKABLE_DOWN, SP_DOCKABLE_UP);
+                }
+            } else if (dockMode == SplitPanelDockMode.DOWN) {
+                int down = splitter.getOffsetTop() + splitter.getOffsetHeight();
+                int splitBottomPosition = getAbsoluteBottom();
+
+                if (down < splitBottomPosition - BUTTON_HEIGHT_SPACE) {
+                    dockButtonStyle.setTop(down - getSplitterSize(), Style.Unit.PX);
+                    dockButtonStyle.setLeft(getDockBtnContainerHorizontalPosition(), Style.Unit.PX);
+
+                    if (dockButtonState == DockButtonState.UP) {
+                        updateDockButtonStyle(SP_DOCK_BUTTON_DOWN, SP_DOCK_BUTTON_UP);
+                        dockButtonState = DockButtonState.DOWN;
+                    }
+
+                    updateSplitPanelStyle(SP_DOCKABLE_DOWN, SP_DOCKABLE_UP);
+                } else {
+                    dockButtonStyle.setTop(down - (dockButton.getOffsetHeight()), Style.Unit.PX);
+                    dockButtonStyle.setLeft(getDockBtnContainerHorizontalPosition(), Style.Unit.PX);
+
+                    if (dockButtonState == DockButtonState.DOWN) {
+                        updateDockButtonStyle(SP_DOCK_BUTTON_UP, SP_DOCK_BUTTON_DOWN);
+                        dockButtonState = DockButtonState.UP;
+                    }
+
+                    updateSplitPanelStyle(SP_DOCKABLE_UP, SP_DOCKABLE_DOWN);
+                }
+            }
+        }
+    }
+
+    protected boolean isSplitterInBottomChangeArea() {
+        int left = splitter.getOffsetLeft();
+        return left < getAbsoluteBottom() + BUTTON_HEIGHT_SPACE;
+    }
+
+    protected boolean isSplitterInTopChangeArea() {
+        int bottom = splitter.getOffsetTop() + splitter.getOffsetHeight();
+        int splitBottomPosition = getAbsoluteTop() + getAbsoluteBottom();
+        return bottom > splitBottomPosition - BUTTON_HEIGHT_SPACE;
+    }
+
+    private void updateDockButtonStyle(String newStyle, String oldStyle) {
+        dockButton.removeStyleName(oldStyle);
+        dockButton.addStyleName(newStyle);
+    }
+
+    private void updateSplitPanelStyle(String newStyle, String oldStyle) {
+        this.removeStyleName(oldStyle);
+        this.addStyleName(newStyle);
+    }
+
+    private int getDockBtnContainerHorizontalPosition() {
+        return splitWidth / 2 - dockButton.getOffsetWidth() / 2;
+    }
+
+    public int getAbsoluteBottom() {
+        return getOffsetHeight();
+    }
+
+    @Override
+    public void updateSizes() {
+        super.updateSizes();
+
+        splitWidth = splitter.getOffsetWidth();
+
+        if (isAttached()) {
+            updateDockButtonPosition();
+        }
+    }
+
+    @Override
+    public void onMouseDown(Event event) {
+        if (isDockable()
+                && isDocked()
+                && (isMinPositionSet() || isMaxPositionSet())) {
+            return;
+        }
+        super.onMouseDown(event);
+    }
+
+    @Override
+    public void setSplitPosition(String pos) {
+        if (isDockable()
+                && isDocked()
+                && !isExtremePosition(pos)) {
+            setDocked(false);
+        }
+        super.setSplitPosition(pos);
+    }
+
+    protected boolean isMinPositionSet() {
+        return dockMode == SplitPanelDockMode.UP
+                && !minimumPosition.equals("0%")
+                && !minimumPosition.equals("0px");
+    }
+
+    protected boolean isMaxPositionSet() {
+        return dockMode == SplitPanelDockMode.DOWN
+                && !maximumPosition.equals("100%")
+                && !maximumPosition.equals(getAbsoluteBottom() + "px");
+    }
+
+    protected boolean isExtremePosition(String pos) {
+        boolean dockedToLeft = dockMode == SplitPanelDockMode.UP
+                && (pos.equals("0%") || pos.equals("0px"));
+        boolean dockedToRight = dockMode == SplitPanelDockMode.DOWN
+                && (pos.equals("100%") || pos.equals(getAbsoluteBottom() + "px"));
+        return dockedToLeft || dockedToRight;
+    }
+
+    @Override
+    public void onMouseUp(Event event) {
+        super.onMouseUp(event);
+
+        splitWidth = splitter.getOffsetWidth();
+    }
+
+    @Override
+    protected void onDetach() {
+        super.onDetach();
+
+        if (dockButtonContainer != null) {
+            dockButtonContainer.removeFromParent();
+        }
+    }
+
+    @Override
+    protected String checkSplitPositionLimits(String pos) {
+        return isDocked() ? pos : super.checkSplitPositionLimits(pos);
+    }
+
+    @Override
+    public void setPositionReversed(boolean reversed) {
+        super.setPositionReversed(reversed);
+
+        this.reversed = reversed;
+    }
+
+    protected void setDocked(boolean docked) {
+        if (this.docked != docked) {
+            this.docked = docked;
+        }
+    }
+
+    protected boolean isDocked() {
+        return docked;
+    }
+}

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaDockableSplitPanel.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaDockableSplitPanel.java
@@ -14,22 +14,27 @@
  * limitations under the License.
  */
 
-package com.haulmont.cuba.web.widgets.client.split;
+package com.haulmont.cuba.web.widgets;
 
-import com.vaadin.shared.annotations.NoLayout;
-import com.vaadin.shared.ui.splitpanel.VerticalSplitPanelState;
+import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
 
-public class CubaVerticalSplitPanelState extends VerticalSplitPanelState {
+public interface CubaDockableSplitPanel {
 
-    @NoLayout
-    public boolean dockable = false;
+    public boolean isDockable();
 
-    @NoLayout
-    public SplitPanelDockMode dockMode = SplitPanelDockMode.TOP;
+    public void setDockable(boolean usePinButton);
 
-    @NoLayout
-    public String defaultPosition = null;
+    public void setDockMode(SplitPanelDockMode dockMode);
 
-    @NoLayout
-    public String beforeDockPosition = null;
+    public SplitPanelDockMode getDockMode();
+
+    public String getDefaultPosition();
+
+    /**
+     * Set default position for dock mode
+     *
+     * @param defaultPosition default position
+     */
+    public void setDefaultPosition(String defaultPosition);
+
 }

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaHorizontalSplitPanel.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaHorizontalSplitPanel.java
@@ -16,18 +16,18 @@
 
 package com.haulmont.cuba.web.widgets;
 
-import com.haulmont.cuba.web.widgets.client.split.CubaHorizontalSplitPanelServerRpc;
+import com.haulmont.cuba.web.widgets.client.split.CubaDockableSplitPanelServerRpc;
 import com.haulmont.cuba.web.widgets.client.split.CubaHorizontalSplitPanelState;
 import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
 import com.vaadin.ui.HorizontalSplitPanel;
 
-public class CubaHorizontalSplitPanel extends HorizontalSplitPanel {
+public class CubaHorizontalSplitPanel extends HorizontalSplitPanel implements CubaDockableSplitPanel {
 
     public CubaHorizontalSplitPanel() {
         super();
 
-        CubaHorizontalSplitPanelServerRpc serverRpc =
-                (CubaHorizontalSplitPanelServerRpc) position -> getState().beforeDockPosition = position;
+        CubaDockableSplitPanelServerRpc serverRpc =
+                (CubaDockableSplitPanelServerRpc) position -> getState().beforeDockPosition = position;
 
         registerRpc(serverRpc);
     }
@@ -42,24 +42,32 @@ public class CubaHorizontalSplitPanel extends HorizontalSplitPanel {
         return (CubaHorizontalSplitPanelState) super.getState(markAsDirty);
     }
 
+    @Override
     public boolean isDockable() {
         return getState(false).dockable;
     }
 
+    @Override
     public void setDockable(boolean usePinButton) {
         if (isDockable() != usePinButton) {
             getState().dockable = usePinButton;
         }
     }
 
+    @Override
     public void setDockMode(SplitPanelDockMode dockMode) {
+        if (dockMode == SplitPanelDockMode.TOP || dockMode == SplitPanelDockMode.BOTTOM) {
+            throw new IllegalStateException("Dock mode " + dockMode.name() + " is not available for the horizontally oriented SplitPanel.");
+        }
         getState().dockMode = dockMode;
     }
 
+    @Override
     public SplitPanelDockMode getDockMode() {
         return getState(false).dockMode;
     }
 
+    @Override
     public String getDefaultPosition() {
         return getState(false).defaultPosition;
     }
@@ -69,6 +77,7 @@ public class CubaHorizontalSplitPanel extends HorizontalSplitPanel {
      *
      * @param defaultPosition default position
      */
+    @Override
     public void setDefaultPosition(String defaultPosition) {
         getState().defaultPosition = defaultPosition;
     }

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaVerticalSplitPanel.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaVerticalSplitPanel.java
@@ -16,18 +16,18 @@
 
 package com.haulmont.cuba.web.widgets;
 
-import com.haulmont.cuba.web.widgets.client.split.CubaHorizontalSplitPanelServerRpc;
+import com.haulmont.cuba.web.widgets.client.split.CubaDockableSplitPanelServerRpc;
 import com.haulmont.cuba.web.widgets.client.split.CubaVerticalSplitPanelState;
 import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
 import com.vaadin.ui.VerticalSplitPanel;
 
-public class CubaVerticalSplitPanel extends VerticalSplitPanel {
+public class CubaVerticalSplitPanel extends VerticalSplitPanel implements CubaDockableSplitPanel {
 
     public CubaVerticalSplitPanel() {
         super();
 
-        CubaHorizontalSplitPanelServerRpc serverRpc =
-                (CubaHorizontalSplitPanelServerRpc) position -> getState().beforeDockPosition = position;
+        CubaDockableSplitPanelServerRpc serverRpc =
+                (CubaDockableSplitPanelServerRpc) position -> getState().beforeDockPosition = position;
 
         registerRpc(serverRpc);
     }
@@ -42,24 +42,32 @@ public class CubaVerticalSplitPanel extends VerticalSplitPanel {
         return (CubaVerticalSplitPanelState) super.getState(markAsDirty);
     }
 
+    @Override
     public boolean isDockable() {
         return getState(false).dockable;
     }
 
+    @Override
     public void setDockable(boolean usePinButton) {
         if (isDockable() != usePinButton) {
             getState().dockable = usePinButton;
         }
     }
 
+    @Override
     public void setDockMode(SplitPanelDockMode dockMode) {
+        if (dockMode == SplitPanelDockMode.LEFT || dockMode == SplitPanelDockMode.RIGHT) {
+            throw new IllegalStateException("Dock mode " + dockMode.name() + " is not available for the vertically oriented SplitPanel.");
+        }
         getState().dockMode = dockMode;
     }
 
+    @Override
     public SplitPanelDockMode getDockMode() {
         return getState(false).dockMode;
     }
 
+    @Override
     public String getDefaultPosition() {
         return getState(false).defaultPosition;
     }
@@ -69,6 +77,7 @@ public class CubaVerticalSplitPanel extends VerticalSplitPanel {
      *
      * @param defaultPosition default position
      */
+    @Override
     public void setDefaultPosition(String defaultPosition) {
         getState().defaultPosition = defaultPosition;
     }

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaVerticalSplitPanel.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/CubaVerticalSplitPanel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.cuba.web.widgets;
+
+import com.haulmont.cuba.web.widgets.client.split.CubaHorizontalSplitPanelServerRpc;
+import com.haulmont.cuba.web.widgets.client.split.CubaVerticalSplitPanelState;
+import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
+import com.vaadin.ui.VerticalSplitPanel;
+
+public class CubaVerticalSplitPanel extends VerticalSplitPanel {
+
+    public CubaVerticalSplitPanel() {
+        super();
+
+        CubaHorizontalSplitPanelServerRpc serverRpc =
+                (CubaHorizontalSplitPanelServerRpc) position -> getState().beforeDockPosition = position;
+
+        registerRpc(serverRpc);
+    }
+
+    @Override
+    protected CubaVerticalSplitPanelState getState() {
+        return (CubaVerticalSplitPanelState) super.getState();
+    }
+
+    @Override
+    protected CubaVerticalSplitPanelState getState(boolean markAsDirty) {
+        return (CubaVerticalSplitPanelState) super.getState(markAsDirty);
+    }
+
+    public boolean isDockable() {
+        return getState(false).dockable;
+    }
+
+    public void setDockable(boolean usePinButton) {
+        if (isDockable() != usePinButton) {
+            getState().dockable = usePinButton;
+        }
+    }
+
+    public void setDockMode(SplitPanelDockMode dockMode) {
+        getState().dockMode = dockMode;
+    }
+
+    public SplitPanelDockMode getDockMode() {
+        return getState(false).dockMode;
+    }
+
+    public String getDefaultPosition() {
+        return getState(false).defaultPosition;
+    }
+
+    /**
+     * Set default position for dock mode
+     *
+     * @param defaultPosition default position
+     */
+    public void setDefaultPosition(String defaultPosition) {
+        getState().defaultPosition = defaultPosition;
+    }
+}

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/CubaDockableSplitPanelServerRpc.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/CubaDockableSplitPanelServerRpc.java
@@ -19,7 +19,7 @@ package com.haulmont.cuba.web.widgets.client.split;
 import com.vaadin.shared.annotations.Delayed;
 import com.vaadin.shared.communication.ServerRpc;
 
-public interface CubaHorizontalSplitPanelServerRpc extends ServerRpc {
+public interface CubaDockableSplitPanelServerRpc extends ServerRpc {
 
     @Delayed
     void setBeforeDockPosition(String position);

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelState.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/CubaVerticalSplitPanelState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016 Haulmont.
+ * Copyright (c) 2008-2020 Haulmont.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,17 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.haulmont.cuba.web.widgets.client.split;
 
-public enum SplitPanelDockMode {
-    LEFT,
-    RIGHT,
-    UP,
-    DOWN;
+import com.vaadin.shared.annotations.NoLayout;
+import com.vaadin.shared.ui.splitpanel.VerticalSplitPanelState;
 
-    SplitPanelDockMode() {
-    }
+public class CubaVerticalSplitPanelState extends VerticalSplitPanelState {
+
+    @NoLayout
+    public boolean dockable = false;
+
+    @NoLayout
+    public SplitPanelDockMode dockMode = SplitPanelDockMode.UP;
+
+    @NoLayout
+    public String defaultPosition = null;
+
+    @NoLayout
+    public String beforeDockPosition = null;
 }

--- a/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/SplitPanelDockMode.java
+++ b/modules/web-widgets/src/com/haulmont/cuba/web/widgets/client/split/SplitPanelDockMode.java
@@ -20,8 +20,8 @@ package com.haulmont.cuba.web.widgets.client.split;
 public enum SplitPanelDockMode {
     LEFT,
     RIGHT,
-    UP,
-    DOWN;
+    TOP,
+    BOTTOM;
 
     SplitPanelDockMode() {
     }

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebSplitPanel.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebSplitPanel.java
@@ -25,6 +25,7 @@ import com.haulmont.cuba.gui.components.SizeUnit;
 import com.haulmont.cuba.gui.components.SplitPanel;
 import com.haulmont.cuba.gui.components.sys.FrameImplementation;
 import com.haulmont.cuba.web.widgets.CubaHorizontalSplitPanel;
+import com.haulmont.cuba.web.widgets.CubaVerticalSplitPanel;
 import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
 import com.vaadin.server.Sizeable.Unit;
 import com.vaadin.ui.AbstractSplitPanel;
@@ -91,10 +92,11 @@ public class WebSplitPanel extends WebAbstractComponent<AbstractSplitPanel> impl
                 }
             };
         } else {
-            component = new VerticalSplitPanel() {
+            component = new CubaVerticalSplitPanel() {
                 @Override
                 public void setSplitPosition(float pos, Unit unit, boolean reverse) {
                     currentPosition = this.getSplitPosition();
+                    inverse = this.isSplitPositionReversed();
 
                     super.setSplitPosition(pos, unit, reverse);
                 }
@@ -356,34 +358,44 @@ public class WebSplitPanel extends WebAbstractComponent<AbstractSplitPanel> impl
     @Override
     public void setDockable(boolean dockable) {
         if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            throw new IllegalStateException("Docking is not available for the vertically oriented SplitPanel.");
+            ((CubaVerticalSplitPanel) component).setDockable(dockable);
+        } else {
+            ((CubaHorizontalSplitPanel) component).setDockable(dockable);
         }
-        ((CubaHorizontalSplitPanel) component).setDockable(dockable);
     }
 
     @Override
     public boolean isDockable() {
         if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            return false;
+            return ((CubaVerticalSplitPanel) component).isDockable();
         }
         return ((CubaHorizontalSplitPanel) component).isDockable();
     }
 
     @Override
     public void setDockMode(DockMode dockMode) {
-        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            throw new IllegalStateException("Docking is not available for the vertically oriented SplitPanel.");
-        }
         SplitPanelDockMode mode = SplitPanelDockMode.valueOf(dockMode.name());
-        ((CubaHorizontalSplitPanel) component).setDockMode(mode);
+        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
+            if (mode == SplitPanelDockMode.LEFT || mode == SplitPanelDockMode.RIGHT) {
+                throw new IllegalStateException("Dock mode " + mode.name() + " is not available for the vertically oriented SplitPanel.");
+            }
+            ((CubaVerticalSplitPanel) component).setDockMode(mode);
+        } else {
+            if (mode == SplitPanelDockMode.UP || mode == SplitPanelDockMode.DOWN) {
+                throw new IllegalStateException("Dock mode " + mode.name() + " is not available for the horizontally oriented SplitPanel.");
+            }
+            ((CubaHorizontalSplitPanel) component).setDockMode(mode);
+        }
     }
 
     @Override
     public DockMode getDockMode() {
+        SplitPanelDockMode mode;
         if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            return null;
+            mode = ((CubaVerticalSplitPanel) component).getDockMode();
+        } else {
+            mode = ((CubaHorizontalSplitPanel) component).getDockMode();
         }
-        SplitPanelDockMode mode = ((CubaHorizontalSplitPanel) component).getDockMode();
         return DockMode.valueOf(mode.name());
     }
 

--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebSplitPanel.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebSplitPanel.java
@@ -24,12 +24,12 @@ import com.haulmont.cuba.gui.components.Frame;
 import com.haulmont.cuba.gui.components.SizeUnit;
 import com.haulmont.cuba.gui.components.SplitPanel;
 import com.haulmont.cuba.gui.components.sys.FrameImplementation;
+import com.haulmont.cuba.web.widgets.CubaDockableSplitPanel;
 import com.haulmont.cuba.web.widgets.CubaHorizontalSplitPanel;
 import com.haulmont.cuba.web.widgets.CubaVerticalSplitPanel;
 import com.haulmont.cuba.web.widgets.client.split.SplitPanelDockMode;
 import com.vaadin.server.Sizeable.Unit;
 import com.vaadin.ui.AbstractSplitPanel;
-import com.vaadin.ui.VerticalSplitPanel;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.dom4j.Element;
@@ -357,45 +357,23 @@ public class WebSplitPanel extends WebAbstractComponent<AbstractSplitPanel> impl
 
     @Override
     public void setDockable(boolean dockable) {
-        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            ((CubaVerticalSplitPanel) component).setDockable(dockable);
-        } else {
-            ((CubaHorizontalSplitPanel) component).setDockable(dockable);
-        }
+        ((CubaDockableSplitPanel) component).setDockable(dockable);
     }
 
     @Override
     public boolean isDockable() {
-        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            return ((CubaVerticalSplitPanel) component).isDockable();
-        }
-        return ((CubaHorizontalSplitPanel) component).isDockable();
+        return ((CubaDockableSplitPanel) component).isDockable();
     }
 
     @Override
     public void setDockMode(DockMode dockMode) {
         SplitPanelDockMode mode = SplitPanelDockMode.valueOf(dockMode.name());
-        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            if (mode == SplitPanelDockMode.LEFT || mode == SplitPanelDockMode.RIGHT) {
-                throw new IllegalStateException("Dock mode " + mode.name() + " is not available for the vertically oriented SplitPanel.");
-            }
-            ((CubaVerticalSplitPanel) component).setDockMode(mode);
-        } else {
-            if (mode == SplitPanelDockMode.UP || mode == SplitPanelDockMode.DOWN) {
-                throw new IllegalStateException("Dock mode " + mode.name() + " is not available for the horizontally oriented SplitPanel.");
-            }
-            ((CubaHorizontalSplitPanel) component).setDockMode(mode);
-        }
+        ((CubaDockableSplitPanel) component).setDockMode(mode);
     }
 
     @Override
     public DockMode getDockMode() {
-        SplitPanelDockMode mode;
-        if (orientation == SplitPanel.ORIENTATION_VERTICAL) {
-            mode = ((CubaVerticalSplitPanel) component).getDockMode();
-        } else {
-            mode = ((CubaHorizontalSplitPanel) component).getDockMode();
-        }
+        SplitPanelDockMode mode = ((CubaDockableSplitPanel) component).getDockMode();
         return DockMode.valueOf(mode.name());
     }
 

--- a/modules/web/themes/halo/components/splitpanel/splitpanel.scss
+++ b/modules/web/themes/halo/components/splitpanel/splitpanel.scss
@@ -62,7 +62,7 @@ $cuba-splitpanel-dock-button-width: round($v-unit-size / 3) !default;
   .c-splitpanel-dock-button-vertical {
       cursor: pointer;
       height: round($v-unit-size/3);
-      line-height: 7px;
+      line-height: round($v-unit-size/3);
       background: $v-panel-background-color;
       border: $border-width solid $border-color;
       font-family: FontAwesome;

--- a/modules/web/themes/halo/components/splitpanel/splitpanel.scss
+++ b/modules/web/themes/halo/components/splitpanel/splitpanel.scss
@@ -20,6 +20,7 @@
  * @group splitpanel
  */
 $cuba-splitpanel-splitter-width: 3px !default;
+
 /**
  * The width of split panel dock button.
  * @group splitpanel
@@ -58,6 +59,21 @@ $cuba-splitpanel-dock-button-width: round($v-unit-size / 3) !default;
     display: inline-block;
   }
 
+  .c-splitpanel-dock-button-vertical {
+      cursor: pointer;
+      height: round($v-unit-size/3);
+      line-height: 7px;
+      background: $v-panel-background-color;
+      border: $border-width solid $border-color;
+      font-family: FontAwesome;
+      color: $button-color;
+      font-size: 12px;
+      text-align: center;
+      padding-left: round($v-unit-size/2);
+      padding-right: round($v-unit-size/2);
+      display: block;
+    }
+
   .c-splitpanel-dock-button-left {
     border-right-color: $v-panel-background-color;
     margin-left: -($cuba-splitpanel-splitter-width - $border-width);
@@ -70,11 +86,31 @@ $cuba-splitpanel-dock-button-width: round($v-unit-size / 3) !default;
     border-radius: 0 $border-radius $border-radius 0;
   }
 
+  .c-splitpanel-dock-button-up {
+    border-bottom-color: $v-panel-background-color;
+    margin-top: 0;
+    border-radius: $border-radius $border-radius 0 0;
+  }
+
+  .c-splitpanel-dock-button-down {
+    border-top-color: $v-panel-background-color;
+    margin-top: 0;
+    border-radius: 0 0 $border-radius $border-radius;
+  }
+
   .c-splitpanel-dock-button-left:after {
     content: "\f053";
   }
 
   .c-splitpanel-dock-button-right:after {
     content: "\f054";
+  }
+
+  .c-splitpanel-dock-button-up:after {
+    content: "\f077";
+  }
+
+  .c-splitpanel-dock-button-down:after {
+    content: "\f078";
   }
 }


### PR DESCRIPTION
Until now SplitPanel component only support docking for `Horizontal` orientation. This PR adds support for docking with `Vertical` orientation.