### PR TITLE
#818 - fix: find default datatype for a java class

### DIFF
--- a/modules/global/src/com/haulmont/cuba/core/sys/DatatypeRegistryImpl.java
+++ b/modules/global/src/com/haulmont/cuba/core/sys/DatatypeRegistryImpl.java
@@ -96,9 +96,18 @@ public class DatatypeRegistryImpl implements DatatypeRegistry {
 
     @Override
     public String getIdByJavaClass(Class<?> javaClass) {
-        for (Map.Entry<String, Datatype> entry : datatypeById.entrySet()) {
-            if (entry.getValue().getJavaClass().equals(javaClass))
-                return entry.getKey();
+        final Datatype datatype = datatypeByClass.get(javaClass); // default datatypes
+        if (datatype != null) {
+            for (Map.Entry<String, Datatype> entry : datatypeById.entrySet()) {
+                if (entry.getValue() == datatype) {
+                    return entry.getKey();
+                }
+            }
+        } else {
+            for (Map.Entry<String, Datatype> entry : datatypeById.entrySet()) {
+                if (entry.getValue().getJavaClass().equals(javaClass))
+                    return entry.getKey();
+            }
         }
         throw new IllegalArgumentException("No datatype registered for " + javaClass);
     }


### PR DESCRIPTION
As described in #818 we have an issue with Application Settings when we declare custom datatype and assign it to java class that already has embedded datatype (for example, `IntegerDatatype` and `YearDatatype` from one of Cuba demo projects - both of datatypes assigned to `Integer.class`).

File `metadata.xml` has attribute `default` for `datatypes/datatype` field. And its purpose to use datatype marked with `default=true` as default datatype for specified java class.

But method `DatatypeRegistryImpl.getIdByJavaClass()` ignores this logic and returns first found datatype from the registry. Due to nature of backing data structures (hash map) there is no certainty that returned datatype will be default.

As a result when you open Application Settings and edit property `cuba.bruteForceProtection.maxLoginAttemptsNumber` our custom YearDatatype converts value 5 to 2005 :)

So I reimplemented this method.