### PR TITLE
Ability to enter a user comment before sending an error repor from the screen ExceptionDialog...

### DIFF
--- a/modules/core/src/com/haulmont/cuba/core/app/exceptionemail/exception-report-template-body.gsp
+++ b/modules/core/src/com/haulmont/cuba/core/app/exceptionemail/exception-report-template-body.gsp
@@ -4,5 +4,6 @@
 <p>${toHtml(errorMessage)}</p>
 <p>${toHtml(stacktrace)}</p>
 <p>User login: ${user.getLogin()}</p>
+<p>User message: ${toHtml(userMessage)}</p>
 </body>
 </html>

--- a/modules/web/src/com/haulmont/cuba/web/exception/ExceptionDialog.java
+++ b/modules/web/src/com/haulmont/cuba/web/exception/ExceptionDialog.java
@@ -62,6 +62,8 @@ public class ExceptionDialog extends CubaWindow {
 
     protected TextArea stackTraceTextArea;
 
+    protected TextArea userMessageTextArea;
+
     protected Button copyButton;
 
     protected Button showStackTraceButton;
@@ -183,14 +185,25 @@ public class ExceptionDialog extends CubaWindow {
 
         if (userSessionSource.getUserSession() != null) {
             if (!StringUtils.isBlank(clientConfig.getSupportEmail())) {
+                userMessageTextArea = new TextArea();
+                userMessageTextArea.setSizeFull();
+                userMessageTextArea.setWordWrap(true);
+                userMessageTextArea.setWidth(100, Unit.PERCENTAGE);
+                userMessageTextArea.setHeight(theme.get("cuba.web.ExceptionDialog.textArea.height"));
+                userMessageTextArea.setMaxLength(500);
+                userMessageTextArea.setCaption(messages.getMainMessage("exceptionDialog.userMessageTextArea.caption"));
+
+                mainLayout.addComponent(userMessageTextArea, 1);
+
                 Button reportButton = new CubaButton(messages.getMainMessage("exceptionDialog.reportBtn"));
                 reportButton.addClickListener(event -> {
-                    sendSupportEmail(text, stackTrace);
+                    sendSupportEmail(text, stackTrace, userMessageTextArea.getValue() );
                     reportButton.setEnabled(false);
                 });
                 buttonsLayout.addComponent(reportButton);
 
                 if (ui.isTestMode()) {
+                    userMessageTextArea.setCubaId("userMessageTextArea");
                     reportButton.setCubaId("errorReportButton");
                 }
             }
@@ -349,7 +362,7 @@ public class ExceptionDialog extends CubaWindow {
         }
     }
 
-    public void sendSupportEmail(String message, String stackTrace) {
+    public void sendSupportEmail(String message, String stackTrace, String userMessage) {
         try {
             User user = userSessionSource.getUserSession().getUser();
             String date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(timeSource.currentTimestamp());
@@ -360,6 +373,7 @@ public class ExceptionDialog extends CubaWindow {
             binding.put("stacktrace", stackTrace);
             binding.put("systemId", clientConfig.getSystemID());
             binding.put("userLogin", user.getLogin());
+            binding.put("userMessage", userMessage);
 
             if (MapUtils.isNotEmpty(additionalExceptionReportBinding)) {
                 binding.putAll(additionalExceptionReportBinding);

--- a/modules/web/src/com/haulmont/cuba/web/messages.properties
+++ b/modules/web/src/com/haulmont/cuba/web/messages.properties
@@ -231,3 +231,4 @@ menuCollapseGlyph = «
 menuExpandGlyph = »
 
 accessDenied.detailedMessage=Access denied for '%s' and permission '%s'.\nYou can turn off detailed message by enabling "cuba.web.productionMode" application property
+exceptionDialog.userMessageTextArea.caption=Describe the actions that led to this error:

--- a/modules/web/src/com/haulmont/cuba/web/messages_ru.properties
+++ b/modules/web/src/com/haulmont/cuba/web/messages_ru.properties
@@ -233,3 +233,4 @@ menuCollapseGlyph = «
 menuExpandGlyph = »
 
 accessDenied.detailedMessage=Доступ запрещен для '%s' и разрешения '%s'.\nВы можете отключить подробное сообщение, включив свойство приложения "cuba.web.productionMode"
+exceptionDialog.userMessageTextArea.caption=Опишите действия, которые привели к ошибке:


### PR DESCRIPTION
...to report your actions before an error occurs or other details of the problem.
https://www.cuba-platform.ru/discuss/t/vozmozhnost-soprovodit-kommentariem-otpravku-otcheta-ob-isklyucheniyah/4714/2

The userMessageTextArea element has been added to the ExceptionDialog screen.
The sendSupportEmail method and the execution-report-template-body template have been modified to send content from userMessageTextArea.