### PR TITLE
#3098 AbstractBeansMetadata doesn't return spring beans without interface as available

### DIFF
--- a/modules/core/src/com/haulmont/cuba/core/app/AbstractBeansMetadata.java
+++ b/modules/core/src/com/haulmont/cuba/core/app/AbstractBeansMetadata.java
@@ -92,14 +92,14 @@ public abstract class AbstractBeansMetadata {
                         addMethod(methods, methodInfo);
                     }
                 }
+            }
 
-                if (methods.isEmpty()) {
-                    for (Method method : bean.getClass().getMethods()) {
-                        if (!method.getDeclaringClass().equals(Object.class) && isMethodAvailable(method)) {
-                            List<MethodParameterInfo> methodParameters = getMethodParameters(method);
-                            MethodInfo methodInfo = new MethodInfo(method.getName(), methodParameters);
-                            addMethod(methods, methodInfo);
-                        }
+            if (methods.isEmpty()) {
+                for (Method method : bean.getClass().getMethods()) {
+                    if (!method.getDeclaringClass().equals(Object.class) && isMethodAvailable(method)) {
+                        List<MethodParameterInfo> methodParameters = getMethodParameters(method);
+                        MethodInfo methodInfo = new MethodInfo(method.getName(), methodParameters);
+                        addMethod(methods, methodInfo);
                     }
                 }
             }


### PR DESCRIPTION
See detailed explanation of the problem in issue https://github.com/cuba-platform/cuba/issues/3098

In case of bean has no interfaces it is necessary to check methods of bean itself. Currenly such check will not reached and bean excluded from available beans list.