### PR TITLE
fixing http 403 forbidden in uberJar

### DIFF
--- a/modules/web/src/com/haulmont/cuba/web/sys/CubaApplicationServlet.java
+++ b/modules/web/src/com/haulmont/cuba/web/sys/CubaApplicationServlet.java
@@ -371,7 +371,7 @@ public class CubaApplicationServlet extends VaadinServlet {
         if (isUberJar) {
             String resourcePath = resourceUrl.getPath();
             if ("jar".equals(resourceUrl.getProtocol())) {
-                if (resourcePath.contains("!/LIB-INF/app/VAADIN/")) {
+                if (resourcePath.contains("!/LIB-INF/app/VAADIN/") || resourcePath.contains("!/LIB-INF/app/WEB-INF/classes/VAADIN/")) {
                     return true;
                 }
             }


### PR DESCRIPTION
See https://www.cuba-platform.com/discuss/t/uberjar-sw-responsive-http-403-forbidden-on-vaadin-responsivelayout-styles-css/12866