### PR TITLE
Update WebFileDescriptorResource.java

### DIFF
--- a/modules/web/src/com/haulmont/cuba/web/gui/components/WebFileDescriptorResource.java
+++ b/modules/web/src/com/haulmont/cuba/web/gui/components/WebFileDescriptorResource.java
@@ -93,7 +93,7 @@ public class WebFileDescriptorResource extends WebAbstractStreamSettingsResource
 
         return name.append(baseName)
                 .append('-')
-                .append(UUID.randomUUID().toString())
+                .append(fileDescriptor.getId().toString())
                 .append('.')
                 .append(extension)
                 .toString();


### PR DESCRIPTION
The Web-Server cannot cache files if an unique UUID is always appended to the file name. To garantie uniquness and to be able to cache the file, the ID of the file itself is taken.

See message in the cuba forum: https://forum.cuba-platform.com/t/impossible-to-cache-static-files-k-webfiledescriptorresource-adds-random-uuid-to-file-name/15414
