### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ before_install:
   - ./gradlew --no-daemon startDb createTestDb
 
 install:
-  - ./gradlew --no-daemon assemble
+  - ./gradlew assemble
 
 script:
-  - ./gradlew --no-daemon test javadoc -Dlogback.configurationFile=com/haulmont/cuba/test-silent-logback.xml
-  - ./gradlew --no-daemon dependencyUpdates -PdependencyUpdates -Drevision=release
+  - ./gradlew test javadoc -Dlogback.configurationFile=com/haulmont/cuba/test-silent-logback.xml
+  - ./gradlew dependencyUpdates -PdependencyUpdates -Drevision=release
 
 cache:
   directories:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
